### PR TITLE
Surface backend login errors

### DIFF
--- a/frontend/src/auth/auth.service.js
+++ b/frontend/src/auth/auth.service.js
@@ -17,9 +17,12 @@ export const login = async ({ loginData }) => {
       { data, status },
       {
         notifyOnSuccess: false,
-        notifyOnFailed: true,
+        notifyOnFailed: false,
       }
     );
+    if (data.success === false) {
+      return { success: false, message: data.message };
+    }
     return data;
   } catch (error) {
     return errorHandler(error);

--- a/frontend/src/redux/auth/actions.js
+++ b/frontend/src/redux/auth/actions.js
@@ -1,6 +1,7 @@
 import * as actionTypes from './types';
 import * as authService from '@/auth';
 import { request } from '@/request';
+import { notification } from 'antd';
 
 export const login =
   ({ loginData }) =>
@@ -24,6 +25,9 @@ export const login =
         payload: data.result,
       });
     } else {
+      if (data?.message) {
+        notification.error({ message: data.message });
+      }
       dispatch({
         type: actionTypes.REQUEST_FAILED,
       });
@@ -43,6 +47,9 @@ export const register =
         type: actionTypes.REGISTER_SUCCESS,
       });
     } else {
+      if (data?.message) {
+        notification.error({ message: data.message });
+      }
       dispatch({
         type: actionTypes.REQUEST_FAILED,
       });
@@ -71,6 +78,9 @@ export const verify =
         payload: data.result,
       });
     } else {
+      if (data?.message) {
+        notification.error({ message: data.message });
+      }
       dispatch({
         type: actionTypes.REQUEST_FAILED,
       });
@@ -99,6 +109,9 @@ export const resetPassword =
         payload: data.result,
       });
     } else {
+      if (data?.message) {
+        notification.error({ message: data.message });
+      }
       dispatch({
         type: actionTypes.REQUEST_FAILED,
       });


### PR DESCRIPTION
## Summary
- return backend error message on failed login attempts
- show notification errors when auth requests fail

## Testing
- `cd frontend && npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot read config file .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f90bb97408333ad752f8f443646d6