### PR TITLE
Use valid default sort fields for paginated endpoints

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/paginatedList.js
+++ b/backend/src/controllers/appControllers/invoiceController/paginatedList.js
@@ -6,7 +6,9 @@ const paginatedList = async (req, res) => {
   const limit = parseInt(req.query.items) || 10;
   const skip = page * limit - limit;
 
-  const { sortBy = 'enabled', sortValue = -1, filter, equal } = req.query;
+  const { sortBy = 'id', sortValue = -1, filter, equal } = req.query;
+  const columns = Model.metadata.columns.map((c) => c.propertyName);
+  const orderBy = columns.includes(sortBy) ? sortBy : 'id';
 
   const where = { removed: false };
   if (filter && equal !== undefined) {
@@ -17,7 +19,7 @@ const paginatedList = async (req, res) => {
     where,
     skip,
     take: limit,
-    order: { [sortBy]: sortValue === -1 ? 'DESC' : 'ASC' },
+    order: { [orderBy]: sortValue === -1 ? 'DESC' : 'ASC' },
   });
   // Calculating total pages
   const pages = Math.ceil(count / limit);

--- a/backend/src/controllers/appControllers/quoteController/paginatedList.js
+++ b/backend/src/controllers/appControllers/quoteController/paginatedList.js
@@ -5,7 +5,9 @@ const paginatedList = async (req, res) => {
   const page = req.query.page || 1;
   const limit = parseInt(req.query.items) || 10;
   const skip = page * limit - limit;
-  const { sortBy = 'enabled', sortValue = -1, filter, equal } = req.query;
+  const { sortBy = 'id', sortValue = -1, filter, equal } = req.query;
+  const columns = Model.metadata.columns.map((c) => c.propertyName);
+  const orderBy = columns.includes(sortBy) ? sortBy : 'id';
 
   const where = { removed: false };
   if (filter && equal !== undefined) {
@@ -16,7 +18,7 @@ const paginatedList = async (req, res) => {
     where,
     skip,
     take: limit,
-    order: { [sortBy]: sortValue === -1 ? 'DESC' : 'ASC' },
+    order: { [orderBy]: sortValue === -1 ? 'DESC' : 'ASC' },
   });
   // Calculating total pages
   const pages = Math.ceil(count / limit);

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
@@ -3,7 +3,9 @@ const paginatedList = async (repository, req, res) => {
   const limit = parseInt(req.query.items) || 10;
   const skip = page * limit - limit;
 
-  const { sortBy = 'enabled', sortValue = -1, filter, equal } = req.query;
+  const { sortBy = 'id', sortValue = -1, filter, equal } = req.query;
+  const columns = repository.metadata.columns.map((c) => c.propertyName);
+  const orderBy = columns.includes(sortBy) ? sortBy : 'id';
   const fieldsArray = req.query.fields ? req.query.fields.split(',') : [];
 
   try {
@@ -20,7 +22,7 @@ const paginatedList = async (repository, req, res) => {
       qb.andWhere(`(${where})`, { q: `%${req.query.q}%` });
     }
 
-    qb.orderBy(`model.${sortBy}`, sortValue == -1 ? 'DESC' : 'ASC');
+    qb.orderBy(`model.${orderBy}`, sortValue == -1 ? 'DESC' : 'ASC');
     qb.skip(skip).take(limit);
 
     const [result, count] = await qb.getManyAndCount();


### PR DESCRIPTION
## Summary
- default `sortBy` to `id` for generic CRUD, invoices, and quotes
- validate `sortBy` against entity metadata before applying sort

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a60501bef48333bf441aaa2cb640d1