### PR TITLE
Ensure payment mode exists before update

### DIFF
--- a/backend/src/controllers/appControllers/paymentModeController/index.js
+++ b/backend/src/controllers/appControllers/paymentModeController/index.js
@@ -36,38 +36,47 @@ methods.delete = async (req, res) => {
 methods.update = async (req, res) => {
   const { id } = req.params;
   const paymentMode = await Model.findOne({ where: { id: req.params.id, removed: false } });
-  const { isDefault = paymentMode.isDefault, enabled = paymentMode.enabled } = req.body;
 
-  // if isDefault:false , we update first - isDefault:true
-  // if enabled:false and isDefault:true , we update first - isDefault:true
-  if (!isDefault || (!enabled && isDefault)) {
-    await Model.update({ id: Not(id), enabled: true }, { isDefault: true });
-  }
-
-  // if isDefault:true and enabled:true, we update other paymentMode and make is isDefault:false
-  if (isDefault && enabled) {
-    await Model.update({ id: Not(id) }, { isDefault: false });
-  }
-
-  const paymentModeCount = await Model.count();
-
-  // if enabled:false and it's only one exist, we can't disable
-  if ((!enabled || !isDefault) && paymentModeCount <= 1) {
-    return res.status(422).json({
+  if (!paymentMode) {
+    return res.status(404).json({
       success: false,
       result: null,
-      message: 'You cannot disable the paymentMode because it is the only existing one',
+      message: 'payment mode not found',
+    });
+  } else {
+    const { isDefault = paymentMode.isDefault, enabled = paymentMode.enabled } = req.body;
+
+    // if isDefault:false , we update first - isDefault:true
+    // if enabled:false and isDefault:true , we update first - isDefault:true
+    if (!isDefault || (!enabled && isDefault)) {
+      await Model.update({ id: Not(id), enabled: true }, { isDefault: true });
+    }
+
+    // if isDefault:true and enabled:true, we update other paymentMode and make is isDefault:false
+    if (isDefault && enabled) {
+      await Model.update({ id: Not(id) }, { isDefault: false });
+    }
+
+    const paymentModeCount = await Model.count();
+
+    // if enabled:false and it's only one exist, we can't disable
+    if ((!enabled || !isDefault) && paymentModeCount <= 1) {
+      return res.status(422).json({
+        success: false,
+        result: null,
+        message: 'You cannot disable the paymentMode because it is the only existing one',
+      });
+    }
+
+    Model.merge(paymentMode, req.body);
+    const result = await Model.save(paymentMode);
+
+    return res.status(200).json({
+      success: true,
+      message: 'paymentMode updated successfully',
+      result,
     });
   }
-
-  Model.merge(paymentMode, req.body);
-  const result = await Model.save(paymentMode);
-
-  return res.status(200).json({
-    success: true,
-    message: 'paymentMode updated successfully',
-    result,
-  });
 };
 
 module.exports = methods;


### PR DESCRIPTION
## Summary
- return 404 if update target payment mode is not found
- defer isDefault/enabled destructuring until payment mode existence confirmed
- only merge and save when a valid payment mode is retrieved

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd backend && npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a608d297648333b457c48d80963d5f