### PR TITLE
Fix invoice and quote processing

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/create.js
+++ b/backend/src/controllers/appControllers/invoiceController/create.js
@@ -3,6 +3,7 @@ const Model = AppDataSource.getRepository('Invoice');
 
 const { calculate } = require('@/helpers');
 const { increaseBySettingKey } = require('@/middlewares/settings');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 const schema = require('./schemaValidate');
 
 const create = async (req, res) => {
@@ -50,16 +51,16 @@ const create = async (req, res) => {
   const fileId = 'invoice-' + result.id + '.pdf';
   result.pdf = fileId;
   const updateResult = await Model.save(result);
-  // Returning successfull response
+  // Returning successful response
 
   increaseBySettingKey({
     settingKey: 'last_invoice_number',
   });
 
-  // Returning successfull response
+  // Returning successful response
   return res.status(200).json({
     success: true,
-    result: updateResult,
+    result: addId(updateResult),
     message: 'Invoice created successfully',
   });
 };

--- a/backend/src/controllers/appControllers/invoiceController/paginatedList.js
+++ b/backend/src/controllers/appControllers/invoiceController/paginatedList.js
@@ -1,5 +1,6 @@
 const { AppDataSource } = require('@/typeorm-data-source');
 const Model = AppDataSource.getRepository('Invoice');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 
 const paginatedList = async (req, res) => {
   const page = req.query.page || 1;
@@ -29,7 +30,7 @@ const paginatedList = async (req, res) => {
   if (count > 0) {
     return res.status(200).json({
       success: true,
-      result,
+      result: addId(result),
       pagination,
       message: 'Successfully found all documents',
     });

--- a/backend/src/controllers/appControllers/invoiceController/read.js
+++ b/backend/src/controllers/appControllers/invoiceController/read.js
@@ -1,5 +1,6 @@
 const { AppDataSource } = require('@/typeorm-data-source');
 const Model = AppDataSource.getRepository('Invoice');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 
 const read = async (req, res) => {
   // Find document by id
@@ -12,10 +13,10 @@ const read = async (req, res) => {
       message: 'No document found ',
     });
   } else {
-    // Return success resposne
+    // Return success response
     return res.status(200).json({
       success: true,
-      result,
+      result: addId(result),
       message: 'we found this document ',
     });
   }

--- a/backend/src/controllers/appControllers/invoiceController/schemaValidate.js
+++ b/backend/src/controllers/appControllers/invoiceController/schemaValidate.js
@@ -1,6 +1,6 @@
 const Joi = require('joi');
 const schema = Joi.object({
-  client: Joi.alternatives().try(Joi.string(), Joi.object()).required(),
+  client: Joi.alternatives().try(Joi.string(), Joi.object(), Joi.number()).required(),
   number: Joi.number().required(),
   year: Joi.number().required(),
   status: Joi.string().required(),

--- a/backend/src/controllers/appControllers/invoiceController/update.js
+++ b/backend/src/controllers/appControllers/invoiceController/update.js
@@ -4,6 +4,7 @@ const Model = AppDataSource.getRepository('Invoice');
 const custom = require('@/controllers/pdfController');
 
 const { calculate } = require('@/helpers');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 const schema = require('./schemaValidate');
 
 const update = async (req, res) => {
@@ -66,11 +67,11 @@ const update = async (req, res) => {
   Model.merge(previousInvoice, body);
   const result = await Model.save(previousInvoice);
 
-  // Returning successfull response
+  // Returning successful response
 
   return res.status(200).json({
     success: true,
-    result,
+    result: addId(result),
     message: 'we update this document ',
   });
 };

--- a/backend/src/controllers/appControllers/quoteController/create.js
+++ b/backend/src/controllers/appControllers/quoteController/create.js
@@ -4,6 +4,7 @@ const Model = AppDataSource.getRepository('Quote');
 const custom = require('@/controllers/pdfController');
 const { increaseBySettingKey } = require('@/middlewares/settings');
 const { calculate } = require('@/helpers');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 
 const create = async (req, res) => {
   const { items = [], taxRate = 0, discount = 0 } = req.body;
@@ -37,16 +38,16 @@ const create = async (req, res) => {
   const fileId = 'quote-' + result.id + '.pdf';
   result.pdf = fileId;
   const updateResult = await Model.save(result);
-  // Returning successfull response
+  // Returning successful response
 
   increaseBySettingKey({
     settingKey: 'last_quote_number',
   });
 
-  // Returning successfull response
+  // Returning successful response
   return res.status(200).json({
     success: true,
-    result: updateResult,
+    result: addId(updateResult),
     message: 'Quote created successfully',
   });
 };

--- a/backend/src/controllers/appControllers/quoteController/paginatedList.js
+++ b/backend/src/controllers/appControllers/quoteController/paginatedList.js
@@ -1,5 +1,6 @@
 const { AppDataSource } = require('@/typeorm-data-source');
 const Model = AppDataSource.getRepository('Quote');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 
 const paginatedList = async (req, res) => {
   const page = req.query.page || 1;
@@ -28,7 +29,7 @@ const paginatedList = async (req, res) => {
   if (count > 0) {
     return res.status(200).json({
       success: true,
-      result,
+      result: addId(result),
       pagination,
       message: 'Successfully found all documents',
     });

--- a/backend/src/controllers/appControllers/quoteController/read.js
+++ b/backend/src/controllers/appControllers/quoteController/read.js
@@ -1,5 +1,6 @@
 const { AppDataSource } = require('@/typeorm-data-source');
 const Model = AppDataSource.getRepository('Quote');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 
 const read = async (req, res) => {
   // Find document by id
@@ -12,10 +13,10 @@ const read = async (req, res) => {
       message: 'No document found ',
     });
   } else {
-    // Return success resposne
+    // Return success response
     return res.status(200).json({
       success: true,
-      result,
+      result: addId(result),
       message: 'we found this document ',
     });
   }

--- a/backend/src/controllers/appControllers/quoteController/update.js
+++ b/backend/src/controllers/appControllers/quoteController/update.js
@@ -4,6 +4,7 @@ const Model = AppDataSource.getRepository('Quote');
 const custom = require('@/controllers/pdfController');
 
 const { calculate } = require('@/helpers');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 
 const update = async (req, res) => {
   const { items = [], taxRate = 0, discount = 0 } = req.body;
@@ -52,11 +53,11 @@ const update = async (req, res) => {
   Model.merge(result, body);
   result = await Model.save(result);
 
-  // Returning successfull response
+  // Returning successful response
 
   return res.status(200).json({
     success: true,
-    result,
+    result: addId(result),
     message: 'we update this document ',
   });
 };

--- a/backend/src/handlers/downloadHandler/downloadPdf.js
+++ b/backend/src/handlers/downloadHandler/downloadPdf.js
@@ -7,7 +7,7 @@ module.exports = downloadPdf = async (req, res, { directory, id }) => {
     let result;
     try {
       const repository = AppDataSource.getRepository(modelName);
-      result = await repository.findOne({ where: { id } });
+      result = await repository.findOne({ where: { id: Number(id) } });
     } catch (e) {
       result = null;
     }
@@ -19,7 +19,7 @@ module.exports = downloadPdf = async (req, res, { directory, id }) => {
 
       // Continue process if result is returned
 
-      const fileId = modelName.toLowerCase() + '-' + result._id + '.pdf';
+      const fileId = modelName.toLowerCase() + '-' + result.id + '.pdf';
       const folderPath = modelName.toLowerCase();
       const targetLocation = `src/public/download/${folderPath}/${fileId}`;
       await custom.generatePdf(

--- a/frontend/src/modules/ErpPanelModule/CreateItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/CreateItem.jsx
@@ -81,7 +81,7 @@ export default function CreateItem({ config, CreateForm }) {
       dispatch(erp.resetAction({ actionType: 'create' }));
       setSubTotal(0);
       setOfferSubTotal(0);
-      navigate(`/${entity.toLowerCase()}/read/${result._id}`);
+      navigate(`/${entity.toLowerCase()}/read/${result.id}`);
     }
     return () => {};
   }, [isSuccess]);


### PR DESCRIPTION
## Summary
- allow numeric client IDs in invoice creation
- return `_id` values for invoice and quote API responses and lists
- fix PDF download handler and frontend navigation

## Testing
- `npm test`
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a623e7b358833386da5d0311e1a5ec