### PR TITLE
Add invoice payment handling and items

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/create.js
+++ b/backend/src/controllers/appControllers/invoiceController/create.js
@@ -42,7 +42,7 @@ const create = async (req, res) => {
   body['total'] = total;
   body['items'] = items;
 
-  let paymentStatus = calculate.sub(total, discount) === 0 ? 'paid' : 'unpaid';
+  let paymentStatus = calculate.sub(total, discount) === 0 ? 'PAID' : 'UNPAID';
 
   body['paymentStatus'] = paymentStatus;
   body['createdBy'] = req.admin.id;

--- a/backend/src/controllers/appControllers/invoiceController/index.js
+++ b/backend/src/controllers/appControllers/invoiceController/index.js
@@ -10,6 +10,7 @@ const update = require('./update');
 const remove = require('./remove');
 const paginatedList = require('./paginatedList');
 const read = require('./read');
+const payments = require('./payments');
 
 methods.mail = sendMail;
 methods.create = create;
@@ -18,5 +19,6 @@ methods.delete = remove;
 methods.summary = summary;
 methods.list = paginatedList;
 methods.read = read;
+methods.payments = payments;
 
 module.exports = methods;

--- a/backend/src/controllers/appControllers/invoiceController/payments.js
+++ b/backend/src/controllers/appControllers/invoiceController/payments.js
@@ -1,0 +1,34 @@
+const { AppDataSource } = require('@/typeorm-data-source');
+const PaymentRepository = AppDataSource.getRepository('Payment');
+const InvoiceRepository = AppDataSource.getRepository('Invoice');
+const { updateInvoicePayment } = require('@/services/invoiceService');
+
+const payments = async (req, res) => {
+  const invoiceId = parseInt(req.params.id, 10);
+  const invoice = await InvoiceRepository.findOne({ where: { id: invoiceId, removed: false } });
+  if (!invoice) {
+    return res.status(404).json({
+      success: false,
+      result: null,
+      message: 'Invoice not found',
+    });
+  }
+
+  const body = {
+    ...req.body,
+    invoice: invoiceId,
+    client: invoice.client,
+    createdBy: req.admin.id,
+  };
+
+  const payment = await PaymentRepository.save(PaymentRepository.create(body));
+  const updatedInvoice = await updateInvoicePayment(invoiceId);
+
+  return res.status(200).json({
+    success: true,
+    result: { payment, invoice: updatedInvoice },
+    message: 'Payment recorded successfully',
+  });
+};
+
+module.exports = payments;

--- a/backend/src/entities/Invoice.js
+++ b/backend/src/entities/Invoice.js
@@ -24,7 +24,7 @@ module.exports = new EntitySchema({
     credit: { type: 'float', default: 0 },
     discount: { type: 'float', default: 0 },
     payment: { type: 'simple-json', nullable: true },
-    paymentStatus: { type: 'varchar', default: 'unpaid' },
+    paymentStatus: { type: 'varchar', default: 'UNPAID' },
     isOverdue: { type: 'boolean', default: false },
     approved: { type: 'boolean', default: false },
     notes: { type: 'text', nullable: true },

--- a/backend/src/entities/InvoiceItem.js
+++ b/backend/src/entities/InvoiceItem.js
@@ -1,0 +1,22 @@
+const { EntitySchema } = require('typeorm');
+
+module.exports = new EntitySchema({
+  name: 'InvoiceItem',
+  tableName: 'invoice_items',
+  columns: {
+    id: { primary: true, type: 'int', generated: true },
+    description: { type: 'text', nullable: true },
+    quantity: { type: 'float' },
+    price: { type: 'float' },
+    total: { type: 'float' },
+    created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+  relations: {
+    invoice: {
+      type: 'many-to-one',
+      target: 'Invoice',
+      joinColumn: { name: 'invoice' },
+      onDelete: 'CASCADE',
+    },
+  },
+});

--- a/backend/src/entities/Payment.js
+++ b/backend/src/entities/Payment.js
@@ -9,7 +9,6 @@ module.exports = new EntitySchema({
     createdBy: { type: 'int' },
     number: { type: 'int' },
     client: { type: 'int' },
-    invoice: { type: 'int' },
     date: { type: 'date', default: () => 'CURRENT_TIMESTAMP' },
     amount: { type: 'float' },
     currency: { type: 'varchar', default: 'NA' },
@@ -19,5 +18,13 @@ module.exports = new EntitySchema({
     pdf: { type: 'varchar', nullable: true },
     updated: { type: 'timestamp', updateDate: true, default: () => 'CURRENT_TIMESTAMP' },
     created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+  relations: {
+    invoice: {
+      type: 'many-to-one',
+      target: 'Invoice',
+      joinColumn: { name: 'invoice' },
+      onDelete: 'CASCADE',
+    },
   },
 });

--- a/backend/src/models/utils/index.js
+++ b/backend/src/models/utils/index.js
@@ -2,7 +2,7 @@ const { basename, extname } = require('path');
 const { globSync } = require('glob');
 
 const entityFiles = globSync('./src/entities/*.js');
-const coreExclusions = ['Admin', 'AdminPassword', 'Setting', 'Product', 'Supplier'];
+const coreExclusions = ['Admin', 'AdminPassword', 'Setting', 'Product', 'Supplier', 'InvoiceItem'];
 
 const constrollersList = [];
 const entityList = [];

--- a/backend/src/routes/appRoutes/appApi.js
+++ b/backend/src/routes/appRoutes/appApi.js
@@ -20,6 +20,10 @@ const routerApp = (entity, controller) => {
     router.route(`/${entity}/mail`).post(catchErrors(controller['mail']));
   }
 
+  if (entity === 'invoice') {
+    router.route(`/invoices/:id/payments`).post(catchErrors(controller['payments']));
+  }
+
   if (entity === 'quote') {
     router.route(`/quotes/:id/convert`).post(catchErrors(controller['convert']));
   }

--- a/backend/src/services/invoiceService.js
+++ b/backend/src/services/invoiceService.js
@@ -1,0 +1,30 @@
+const { AppDataSource } = require('@/typeorm-data-source');
+const { calculate } = require('@/helpers');
+
+const PaymentRepository = AppDataSource.getRepository('Payment');
+const InvoiceRepository = AppDataSource.getRepository('Invoice');
+
+const sumPayments = async (invoiceId) => {
+  const payments = await PaymentRepository.find({ where: { invoice: invoiceId, removed: false } });
+  return payments.reduce((sum, p) => calculate.add(sum, p.amount), 0);
+};
+
+const updateInvoicePayment = async (invoiceId) => {
+  const invoice = await InvoiceRepository.findOne({ where: { id: invoiceId, removed: false } });
+  if (!invoice) return null;
+  const payments = await PaymentRepository.find({ where: { invoice: invoiceId, removed: false } });
+  const paid = payments.reduce((sum, p) => calculate.add(sum, p.amount), 0);
+  const due = calculate.sub(calculate.sub(invoice.total, invoice.discount || 0), paid);
+  let status = 'UNPAID';
+  if (due <= 0) {
+    status = 'PAID';
+  } else if (paid > 0) {
+    status = 'PARTIAL';
+  }
+  invoice.credit = paid;
+  invoice.paymentStatus = status;
+  invoice.payment = payments.map((p) => p.id);
+  return InvoiceRepository.save(invoice);
+};
+
+module.exports = { sumPayments, updateInvoicePayment };

--- a/frontend/src/modules/InvoiceModule/PaymentForm.jsx
+++ b/frontend/src/modules/InvoiceModule/PaymentForm.jsx
@@ -1,0 +1,5 @@
+import PaymentForm from '@/forms/PaymentForm';
+
+export default function InvoicePaymentForm(props) {
+  return <PaymentForm {...props} />;
+}

--- a/frontend/src/modules/InvoiceModule/RecordPaymentModule/components/RecordPayment.jsx
+++ b/frontend/src/modules/InvoiceModule/RecordPaymentModule/components/RecordPayment.jsx
@@ -8,7 +8,7 @@ import useLanguage from '@/locale/useLanguage';
 
 import Loading from '@/components/Loading';
 
-import PaymentForm from '@/forms/PaymentForm';
+import InvoicePaymentForm from '../../PaymentForm';
 import { useNavigate } from 'react-router-dom';
 import calculate from '@/utils/calculate';
 
@@ -41,27 +41,19 @@ export default function RecordPayment({ config }) {
 
   const onSubmit = (fieldsValue) => {
     if (currentInvoice) {
-      const { _id: invoice } = currentInvoice;
-      const client = currentInvoice.client && currentInvoice.client._id;
-      fieldsValue = {
-        ...fieldsValue,
-        invoice,
-        client,
-      };
+      dispatch(
+        erp.addPayment({
+          invoiceId: currentInvoice._id,
+          jsonData: fieldsValue,
+        })
+      );
     }
-
-    dispatch(
-      erp.recordPayment({
-        entity: 'payment',
-        jsonData: fieldsValue,
-      })
-    );
   };
 
   return (
     <Loading isLoading={isLoading}>
       <Form form={form} layout="vertical" onFinish={onSubmit}>
-        <PaymentForm maxAmount={maxAmount} />
+        <InvoicePaymentForm maxAmount={maxAmount} />
         <Form.Item>
           <Button type="primary" htmlType="submit">
             {translate('Record Payment')}

--- a/frontend/src/redux/erp/actions.js
+++ b/frontend/src/redux/erp/actions.js
@@ -124,6 +124,35 @@ export const erp = {
         });
       }
     },
+  addPayment:
+    ({ invoiceId, jsonData }) =>
+    async (dispatch) => {
+      dispatch({
+        type: actionTypes.REQUEST_LOADING,
+        keyState: 'recordPayment',
+        payload: null,
+      });
+
+      let data = await request.post({ entity: `invoices/${invoiceId}/payments`, jsonData });
+
+      if (data.success === true) {
+        dispatch({
+          type: actionTypes.REQUEST_SUCCESS,
+          keyState: 'recordPayment',
+          payload: data.result.payment,
+        });
+        dispatch({
+          type: actionTypes.CURRENT_ITEM,
+          payload: data.result.invoice,
+        });
+      } else {
+        dispatch({
+          type: actionTypes.REQUEST_FAILED,
+          keyState: 'recordPayment',
+          payload: null,
+        });
+      }
+    },
   read:
     ({ entity, id }) =>
     async (dispatch) => {


### PR DESCRIPTION
## Summary
- create `InvoiceItem` entity and relate payments to invoices
- add service and controller for `/invoices/:id/payments`
- expose payment form components for invoice module

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: module is not defined in frontend ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c7b655048333b96e50c81153d3d0