### PR TITLE
fix: allow converting sent quotes

### DIFF
--- a/frontend/src/modules/ErpPanelModule/ReadItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/ReadItem.jsx
@@ -184,7 +184,7 @@ export default function ReadItem({ config, selectedItem, onConvert }) {
           </Button>,
           <Button
             key={`${uniqueId()}`}
-            disabled={currentErp.status?.toLowerCase() !== 'accepted'}
+            disabled={currentErp.status?.toLowerCase() !== 'sent'}
             onClick={() => {
               if (onConvert) {
                 onConvert(currentErp._id);

--- a/frontend/src/redux/erp/actions.js
+++ b/frontend/src/redux/erp/actions.js
@@ -323,6 +323,7 @@ export const erp = {
   convert:
     ({ entity, id }) =>
     async () => {
-      await request.convert({ entity, id });
+      const route = entity.endsWith('s') ? entity : `${entity}s`;
+      await request.convert({ entity: route, id });
     },
 };

--- a/frontend/src/request/request.js
+++ b/frontend/src/request/request.js
@@ -288,7 +288,7 @@ const request = {
   convert: async ({ entity, id }) => {
     try {
       includeToken();
-      const response = await axios.get(`${entity}/convert/${id}`);
+      const response = await axios.post(`${entity}/${id}/convert`, {});
       successHandler(response, {
         notifyOnSuccess: true,
         notifyOnFailed: true,


### PR DESCRIPTION
## Summary
- enable converting quotes in SENT status
- correct convert request endpoint to use POST /quotes/:id/convert

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a3cf4c3c8333af3e410a0f136018