### PR TITLE
Add purchase and stock ledger management

### DIFF
--- a/backend/src/controllers/masterData/purchaseController.js
+++ b/backend/src/controllers/masterData/purchaseController.js
@@ -1,0 +1,13 @@
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
+const purchaseService = require('@/services/purchaseService');
+
+const create = async (req, res) => {
+  const purchase = await purchaseService.create(req.body);
+  return res.status(200).json({
+    success: true,
+    result: addId(purchase),
+    message: 'Purchase recorded successfully',
+  });
+};
+
+module.exports = { create };

--- a/backend/src/controllers/masterData/stockLedgerController.js
+++ b/backend/src/controllers/masterData/stockLedgerController.js
@@ -1,0 +1,13 @@
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
+const stockLedgerService = require('@/services/stockLedgerService');
+
+const list = async (req, res) => {
+  const entries = await stockLedgerService.list();
+  return res.status(200).json({
+    success: true,
+    result: addId(entries),
+    message: 'Stock ledger retrieved successfully',
+  });
+};
+
+module.exports = { list };

--- a/backend/src/entities/Product.js
+++ b/backend/src/entities/Product.js
@@ -8,6 +8,8 @@ module.exports = new EntitySchema({
     name: { type: 'varchar', length: 255 },
     sku: { type: 'varchar', length: 100, nullable: true },
     price: { type: 'decimal', precision: 10, scale: 2, default: 0 },
+    stock: { type: 'float', default: 0 },
+    averageCost: { type: 'decimal', precision: 10, scale: 2, default: 0 },
     description: { type: 'text', nullable: true },
     removed: { type: 'boolean', default: false },
     created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },

--- a/backend/src/entities/Purchase.js
+++ b/backend/src/entities/Purchase.js
@@ -1,0 +1,14 @@
+const { EntitySchema } = require('typeorm');
+
+module.exports = new EntitySchema({
+  name: 'Purchase',
+  tableName: 'purchases',
+  columns: {
+    id: { primary: true, type: 'int', generated: true },
+    supplier: { type: 'int' },
+    date: { type: 'date', default: () => 'CURRENT_TIMESTAMP' },
+    total: { type: 'float', default: 0 },
+    notes: { type: 'text', nullable: true },
+    created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+});

--- a/backend/src/entities/PurchaseItem.js
+++ b/backend/src/entities/PurchaseItem.js
@@ -1,0 +1,27 @@
+const { EntitySchema } = require('typeorm');
+
+module.exports = new EntitySchema({
+  name: 'PurchaseItem',
+  tableName: 'purchase_items',
+  columns: {
+    id: { primary: true, type: 'int', generated: true },
+    quantity: { type: 'float' },
+    cost: { type: 'float' },
+    total: { type: 'float' },
+    created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+  relations: {
+    purchase: {
+      type: 'many-to-one',
+      target: 'Purchase',
+      joinColumn: { name: 'purchase' },
+      onDelete: 'CASCADE',
+    },
+    product: {
+      type: 'many-to-one',
+      target: 'Product',
+      joinColumn: { name: 'product' },
+      onDelete: 'CASCADE',
+    },
+  },
+});

--- a/backend/src/entities/StockLedger.js
+++ b/backend/src/entities/StockLedger.js
@@ -1,0 +1,22 @@
+const { EntitySchema } = require('typeorm');
+
+module.exports = new EntitySchema({
+  name: 'StockLedger',
+  tableName: 'stock_ledger',
+  columns: {
+    id: { primary: true, type: 'int', generated: true },
+    quantity: { type: 'float' },
+    type: { type: 'varchar', length: 50 },
+    ref: { type: 'int', nullable: true },
+    cost: { type: 'float', default: 0 },
+    created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+  relations: {
+    product: {
+      type: 'many-to-one',
+      target: 'Product',
+      joinColumn: { name: 'product' },
+      onDelete: 'CASCADE',
+    },
+  },
+});

--- a/backend/src/models/utils/index.js
+++ b/backend/src/models/utils/index.js
@@ -2,7 +2,17 @@ const { basename, extname } = require('path');
 const { globSync } = require('glob');
 
 const entityFiles = globSync('./src/entities/*.js');
-const coreExclusions = ['Admin', 'AdminPassword', 'Setting', 'Product', 'Supplier', 'InvoiceItem'];
+const coreExclusions = [
+  'Admin',
+  'AdminPassword',
+  'Setting',
+  'Product',
+  'Supplier',
+  'InvoiceItem',
+  'Purchase',
+  'PurchaseItem',
+  'StockLedger',
+];
 
 const constrollersList = [];
 const entityList = [];

--- a/backend/src/routes/masterDataRoutes.js
+++ b/backend/src/routes/masterDataRoutes.js
@@ -2,6 +2,8 @@ const express = require('express');
 const { catchErrors } = require('@/handlers/errorHandlers');
 const productController = require('@/controllers/masterData/productController');
 const supplierController = require('@/controllers/masterData/supplierController');
+const purchaseController = require('@/controllers/masterData/purchaseController');
+const stockLedgerController = require('@/controllers/masterData/stockLedgerController');
 const rbac = require('@/middlewares/rbac');
 
 const router = express.Router();
@@ -27,5 +29,13 @@ router
   .get(rbac(['owner', 'manager']), catchErrors(supplierController.read))
   .patch(rbac(['owner', 'manager']), catchErrors(supplierController.update))
   .delete(rbac(['owner', 'manager']), catchErrors(supplierController.delete));
+
+router
+  .route('/purchases')
+  .post(rbac(['owner', 'manager']), catchErrors(purchaseController.create));
+
+router
+  .route('/stock-ledger')
+  .get(rbac(['owner', 'manager']), catchErrors(stockLedgerController.list));
   
 module.exports = router; 

--- a/backend/src/services/purchaseService.js
+++ b/backend/src/services/purchaseService.js
@@ -1,0 +1,35 @@
+const { AppDataSource } = require('@/typeorm-data-source');
+const { increaseStock } = require('@/utils/stock');
+
+const purchaseRepository = AppDataSource.getRepository('Purchase');
+const itemRepository = AppDataSource.getRepository('PurchaseItem');
+
+const create = async (data) => {
+  const { supplier, date, items = [], notes } = data;
+  const total = items.reduce((sum, i) => sum + i.quantity * i.cost, 0);
+  const purchase = await purchaseRepository.save(
+    purchaseRepository.create({ supplier, date, total, notes })
+  );
+
+  for (const item of items) {
+    const entity = itemRepository.create({
+      purchase: purchase.id,
+      product: item.product,
+      quantity: item.quantity,
+      cost: item.cost,
+      total: item.quantity * item.cost,
+    });
+    await itemRepository.save(entity);
+    await increaseStock({
+      productId: item.product,
+      quantity: item.quantity,
+      cost: item.cost,
+      refId: purchase.id,
+      type: 'PURCHASE',
+    });
+  }
+
+  return purchase;
+};
+
+module.exports = { create };

--- a/backend/src/services/stockLedgerService.js
+++ b/backend/src/services/stockLedgerService.js
@@ -1,0 +1,9 @@
+const { AppDataSource } = require('@/typeorm-data-source');
+
+const repository = AppDataSource.getRepository('StockLedger');
+
+const list = async () => {
+  return repository.find();
+};
+
+module.exports = { list };

--- a/backend/src/typeorm-data-source.js
+++ b/backend/src/typeorm-data-source.js
@@ -17,6 +17,9 @@ const AdminPassword = require('./entities/AdminPassword');
 const Setting = require('./entities/Setting');
 const Product = require('./entities/Product');
 const Supplier = require('./entities/Supplier');
+const Purchase = require('./entities/Purchase');
+const PurchaseItem = require('./entities/PurchaseItem');
+const StockLedger = require('./entities/StockLedger');
 
 const AppDataSource = new DataSource({
   type: 'mysql',
@@ -27,7 +30,22 @@ const AppDataSource = new DataSource({
   database: process.env.DB_NAME || 'erp',
   synchronize: true,
   logging: false,
-  entities: [Client, Invoice, Payment, PaymentMode, Quote, Taxes, Admin, AdminPassword, Setting, Product, Supplier],
+  entities: [
+    Client,
+    Invoice,
+    Payment,
+    PaymentMode,
+    Quote,
+    Taxes,
+    Admin,
+    AdminPassword,
+    Setting,
+    Product,
+    Supplier,
+    Purchase,
+    PurchaseItem,
+    StockLedger,
+  ],
 });
 
 module.exports = { AppDataSource };

--- a/backend/src/utils/stock/index.js
+++ b/backend/src/utils/stock/index.js
@@ -1,0 +1,33 @@
+const { AppDataSource } = require('@/typeorm-data-source');
+
+const productRepository = AppDataSource.getRepository('Product');
+const ledgerRepository = AppDataSource.getRepository('StockLedger');
+
+const calculateAverageCost = (currentQty, currentAvgCost, qty, cost) => {
+  const totalQty = currentQty + qty;
+  if (totalQty === 0) return 0;
+  const totalCost = currentQty * currentAvgCost + qty * cost;
+  return totalCost / totalQty;
+};
+
+const increaseStock = async ({ productId, quantity, cost, refId, type = 'PURCHASE' }) => {
+  const product = await productRepository.findOne({ where: { id: productId } });
+  if (!product) return null;
+
+  const avgCost = calculateAverageCost(product.stock || 0, Number(product.averageCost || 0), quantity, cost);
+  product.stock = (product.stock || 0) + quantity;
+  product.averageCost = avgCost;
+  await productRepository.save(product);
+
+  const ledger = ledgerRepository.create({
+    product: productId,
+    quantity,
+    type,
+    ref: refId,
+    cost,
+  });
+  await ledgerRepository.save(ledger);
+  return product;
+};
+
+module.exports = { increaseStock, calculateAverageCost };

--- a/frontend/src/modules/PurchaseModule/PurchaseForm.jsx
+++ b/frontend/src/modules/PurchaseModule/PurchaseForm.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+const PurchaseForm = ({ onSubmit }) => {
+  const [form, setForm] = useState({ product: '', quantity: 0, cost: 0 });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Product ID</label>
+        <input name="product" value={form.product} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Quantity</label>
+        <input name="quantity" type="number" value={form.quantity} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Cost</label>
+        <input name="cost" type="number" value={form.cost} onChange={handleChange} />
+      </div>
+      <button type="submit">Save Purchase</button>
+    </form>
+  );
+};
+
+export default PurchaseForm;

--- a/frontend/src/modules/PurchaseModule/index.jsx
+++ b/frontend/src/modules/PurchaseModule/index.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PurchaseForm from './PurchaseForm';
+
+const PurchaseModule = () => {
+  const handleSubmit = async (data) => {
+    try {
+      await fetch('/api/purchases', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: [data] }),
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return <PurchaseForm onSubmit={handleSubmit} />;
+};
+
+export default PurchaseModule;

--- a/frontend/src/modules/StockLedgerModule/index.jsx
+++ b/frontend/src/modules/StockLedgerModule/index.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+const StockLedgerModule = () => {
+  const [entries, setEntries] = useState([]);
+
+  useEffect(() => {
+    const fetchEntries = async () => {
+      try {
+        const res = await fetch('/api/stock-ledger');
+        const json = await res.json();
+        if (json.success) {
+          setEntries(json.result);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchEntries();
+  }, []);
+
+  return (
+    <div>
+      <h2>Stock Ledger</h2>
+      <ul>
+        {entries.map((e) => (
+          <li key={e.id}>
+            Product {e.product} | Qty {e.quantity} | {e.type}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default StockLedgerModule;


### PR DESCRIPTION
## Summary
- extend product schema with stock tracking fields
- implement purchase and stock ledger entities with supporting services and routes
- add simple React modules for recording purchases and viewing stock ledger

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9a8a2b4c883339bcacb9f51111e61