### PR TITLE
Add expense and payroll management

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -14,6 +14,7 @@ const adminAuth = require('./controllers/coreControllers/adminAuth');
 const errorHandlers = require('./handlers/errorHandlers');
 const erpApiRouter = require('./routes/appRoutes/appApi');
 const masterDataRoutes = require('./routes/masterDataRoutes.js');
+const expenseRoutes = require('./routes/expenseRoutes.ts');
 
 const fileUpload = require('express-fileupload');
 // create our Express app
@@ -41,6 +42,7 @@ app.use('/api', coreAuthRouter);
 app.use('/api', adminAuth.isValidAuthToken, coreApiRouter);
 app.use('/api', adminAuth.isValidAuthToken, erpApiRouter);
 app.use('/api', adminAuth.isValidAuthToken, masterDataRoutes);
+app.use('/api', adminAuth.isValidAuthToken, expenseRoutes);
 app.use('/download', coreDownloadRouter);
 app.use('/public', corePublicRouter);
 

--- a/backend/src/controllers/appControllers/expenseController/index.js
+++ b/backend/src/controllers/appControllers/expenseController/index.js
@@ -1,0 +1,6 @@
+const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
+const { AppDataSource } = require('@/typeorm-data-source');
+
+const repository = AppDataSource.getRepository('Expense');
+
+module.exports = createCRUDController(repository);

--- a/backend/src/controllers/appControllers/payrollController/index.js
+++ b/backend/src/controllers/appControllers/payrollController/index.js
@@ -1,0 +1,35 @@
+const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
+const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
+const { AppDataSource } = require('@/typeorm-data-source');
+
+const repository = AppDataSource.getRepository('Payroll');
+const expenseRepository = AppDataSource.getRepository('Expense');
+
+const methods = createCRUDController(repository);
+
+methods.create = async (req, res) => {
+  try {
+    req.body.removed = false;
+    const entity = repository.create({ ...req.body });
+    const payroll = await repository.save(entity);
+    const expense = expenseRepository.create({
+      amount: req.body.amount,
+      date: req.body.date,
+      description: req.body.description,
+      employee: req.body.employee,
+      payroll: payroll.id,
+      category: req.body.category,
+      removed: false,
+    });
+    await expenseRepository.save(expense);
+    return res.status(200).json({
+      success: true,
+      result: addId(payroll),
+      message: 'Successfully Created the document in Model ',
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, result: null, message: error.message });
+  }
+};
+
+module.exports = methods;

--- a/backend/src/entities/Employee.js
+++ b/backend/src/entities/Employee.js
@@ -1,0 +1,15 @@
+const { EntitySchema } = require('typeorm');
+
+module.exports = new EntitySchema({
+  name: 'Employee',
+  tableName: 'employees',
+  columns: {
+    id: { primary: true, type: 'int', generated: true },
+    name: { type: 'varchar', length: 255 },
+    position: { type: 'varchar', length: 255, nullable: true },
+    salary: { type: 'float', default: 0 },
+    removed: { type: 'boolean', default: false },
+    created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+    updated: { type: 'timestamp', updateDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+});

--- a/backend/src/entities/Expense.js
+++ b/backend/src/entities/Expense.js
@@ -1,0 +1,35 @@
+const { EntitySchema } = require('typeorm');
+
+module.exports = new EntitySchema({
+  name: 'Expense',
+  tableName: 'expenses',
+  columns: {
+    id: { primary: true, type: 'int', generated: true },
+    amount: { type: 'float' },
+    date: { type: 'date', default: () => 'CURRENT_TIMESTAMP' },
+    description: { type: 'text', nullable: true },
+    removed: { type: 'boolean', default: false },
+    created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+    updated: { type: 'timestamp', updateDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+  relations: {
+    category: {
+      type: 'many-to-one',
+      target: 'ExpenseCategory',
+      joinColumn: { name: 'category' },
+      onDelete: 'SET NULL',
+    },
+    employee: {
+      type: 'many-to-one',
+      target: 'Employee',
+      joinColumn: { name: 'employee' },
+      onDelete: 'SET NULL',
+    },
+    payroll: {
+      type: 'many-to-one',
+      target: 'Payroll',
+      joinColumn: { name: 'payroll' },
+      onDelete: 'CASCADE',
+    },
+  },
+});

--- a/backend/src/entities/ExpenseCategory.js
+++ b/backend/src/entities/ExpenseCategory.js
@@ -1,0 +1,13 @@
+const { EntitySchema } = require('typeorm');
+
+module.exports = new EntitySchema({
+  name: 'ExpenseCategory',
+  tableName: 'expense_categories',
+  columns: {
+    id: { primary: true, type: 'int', generated: true },
+    name: { type: 'varchar', length: 255 },
+    removed: { type: 'boolean', default: false },
+    created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+    updated: { type: 'timestamp', updateDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+});

--- a/backend/src/entities/Payroll.js
+++ b/backend/src/entities/Payroll.js
@@ -1,0 +1,22 @@
+const { EntitySchema } = require('typeorm');
+
+module.exports = new EntitySchema({
+  name: 'Payroll',
+  tableName: 'payrolls',
+  columns: {
+    id: { primary: true, type: 'int', generated: true },
+    amount: { type: 'float' },
+    date: { type: 'date', default: () => 'CURRENT_TIMESTAMP' },
+    removed: { type: 'boolean', default: false },
+    created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },
+    updated: { type: 'timestamp', updateDate: true, default: () => 'CURRENT_TIMESTAMP' },
+  },
+  relations: {
+    employee: {
+      type: 'many-to-one',
+      target: 'Employee',
+      joinColumn: { name: 'employee' },
+      onDelete: 'SET NULL',
+    },
+  },
+});

--- a/backend/src/routes/expenseRoutes.ts
+++ b/backend/src/routes/expenseRoutes.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import { catchErrors } from '@/handlers/errorHandlers';
+const expenseController = require('@/controllers/appControllers/expenseController');
+const payrollController = require('@/controllers/appControllers/payrollController');
+import rbac from '@/middlewares/rbac';
+
+const router = express.Router();
+
+router
+  .route('/expenses')
+  .get(rbac(['owner', 'manager']), catchErrors(expenseController.list))
+  .post(rbac(['owner', 'manager']), catchErrors(expenseController.create));
+
+router
+  .route('/expenses/:id')
+  .get(rbac(['owner', 'manager']), catchErrors(expenseController.read))
+  .patch(rbac(['owner', 'manager']), catchErrors(expenseController.update))
+  .delete(rbac(['owner', 'manager']), catchErrors(expenseController.delete));
+
+router
+  .route('/payroll')
+  .get(rbac(['owner', 'manager']), catchErrors(payrollController.list))
+  .post(rbac(['owner', 'manager']), catchErrors(payrollController.create));
+
+router
+  .route('/payroll/:id')
+  .get(rbac(['owner', 'manager']), catchErrors(payrollController.read))
+  .patch(rbac(['owner', 'manager']), catchErrors(payrollController.update))
+  .delete(rbac(['owner', 'manager']), catchErrors(payrollController.delete));
+
+export default router;

--- a/backend/src/typeorm-data-source.js
+++ b/backend/src/typeorm-data-source.js
@@ -20,6 +20,10 @@ const Supplier = require('./entities/Supplier');
 const Purchase = require('./entities/Purchase');
 const PurchaseItem = require('./entities/PurchaseItem');
 const StockLedger = require('./entities/StockLedger');
+const Expense = require('./entities/Expense');
+const ExpenseCategory = require('./entities/ExpenseCategory');
+const Employee = require('./entities/Employee');
+const Payroll = require('./entities/Payroll');
 
 const AppDataSource = new DataSource({
   type: 'mysql',
@@ -45,6 +49,10 @@ const AppDataSource = new DataSource({
     Purchase,
     PurchaseItem,
     StockLedger,
+    Expense,
+    ExpenseCategory,
+    Employee,
+    Payroll,
   ],
 });
 

--- a/frontend/src/modules/ExpenseModule/CreateExpenseModule/index.jsx
+++ b/frontend/src/modules/ExpenseModule/CreateExpenseModule/index.jsx
@@ -1,0 +1,15 @@
+import ExpenseForm from '../ExpenseForm';
+
+const CreateExpenseModule = () => {
+  const handleSubmit = async (data) => {
+    await fetch('/api/expenses', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  };
+
+  return <ExpenseForm onSubmit={handleSubmit} />;
+};
+
+export default CreateExpenseModule;

--- a/frontend/src/modules/ExpenseModule/ExpenseDataTableModule/index.jsx
+++ b/frontend/src/modules/ExpenseModule/ExpenseDataTableModule/index.jsx
@@ -1,0 +1,10 @@
+import { ErpLayout } from '@/layout';
+import ErpPanel from '@/modules/ErpPanelModule';
+
+export default function ExpenseDataTableModule({ config }) {
+  return (
+    <ErpLayout>
+      <ErpPanel config={config}></ErpPanel>
+    </ErpLayout>
+  );
+}

--- a/frontend/src/modules/ExpenseModule/ExpenseForm.jsx
+++ b/frontend/src/modules/ExpenseModule/ExpenseForm.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+const ExpenseForm = ({ onSubmit }) => {
+  const [form, setForm] = useState({ amount: 0, description: '' });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Amount</label>
+        <input name="amount" type="number" value={form.amount} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Description</label>
+        <input name="description" value={form.description} onChange={handleChange} />
+      </div>
+      <button type="submit">Save Expense</button>
+    </form>
+  );
+};
+
+export default ExpenseForm;

--- a/frontend/src/modules/ExpenseModule/index.jsx
+++ b/frontend/src/modules/ExpenseModule/index.jsx
@@ -1,0 +1,2 @@
+export { default as ExpenseDataTableModule } from './ExpenseDataTableModule';
+export { default as CreateExpenseModule } from './CreateExpenseModule';

--- a/frontend/src/modules/PayrollModule/CreatePayrollModule/index.jsx
+++ b/frontend/src/modules/PayrollModule/CreatePayrollModule/index.jsx
@@ -1,0 +1,15 @@
+import PayrollForm from '../PayrollForm';
+
+const CreatePayrollModule = () => {
+  const handleSubmit = async (data) => {
+    await fetch('/api/payroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  };
+
+  return <PayrollForm onSubmit={handleSubmit} />;
+};
+
+export default CreatePayrollModule;

--- a/frontend/src/modules/PayrollModule/PayrollDataTableModule/index.jsx
+++ b/frontend/src/modules/PayrollModule/PayrollDataTableModule/index.jsx
@@ -1,0 +1,10 @@
+import { ErpLayout } from '@/layout';
+import ErpPanel from '@/modules/ErpPanelModule';
+
+export default function PayrollDataTableModule({ config }) {
+  return (
+    <ErpLayout>
+      <ErpPanel config={config}></ErpPanel>
+    </ErpLayout>
+  );
+}

--- a/frontend/src/modules/PayrollModule/PayrollForm.jsx
+++ b/frontend/src/modules/PayrollModule/PayrollForm.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+const PayrollForm = ({ onSubmit }) => {
+  const [form, setForm] = useState({ employee: '', amount: 0, description: '' });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Employee ID</label>
+        <input name="employee" value={form.employee} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Amount</label>
+        <input name="amount" type="number" value={form.amount} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Description</label>
+        <input name="description" value={form.description} onChange={handleChange} />
+      </div>
+      <button type="submit">Save Payroll</button>
+    </form>
+  );
+};
+
+export default PayrollForm;

--- a/frontend/src/modules/PayrollModule/index.jsx
+++ b/frontend/src/modules/PayrollModule/index.jsx
@@ -1,0 +1,2 @@
+export { default as PayrollDataTableModule } from './PayrollDataTableModule';
+export { default as CreatePayrollModule } from './CreatePayrollModule';


### PR DESCRIPTION
## Summary
- add Expense, ExpenseCategory, Employee and Payroll entities
- implement payroll controller creating matching expense
- expose expense and payroll CRUD API routes and React modules

## Testing
- `npm test` (fails: Missing script: "test")
- `cd backend && npm test` (fails: Missing script: "test")
- `cd frontend && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a9ac90bc8c8333a3a63cfcdacf1bc0