### PR TITLE
feat: add purchase CRUD endpoints

### DIFF
--- a/backend/src/controllers/masterData/purchaseController.js
+++ b/backend/src/controllers/masterData/purchaseController.js
@@ -1,6 +1,29 @@
 const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
 const purchaseService = require('@/services/purchaseService');
 
+const list = async (req, res) => {
+  const purchases = await purchaseService.list();
+  return res.status(200).json({
+    success: true,
+    result: addId(purchases),
+    message: 'Purchases retrieved successfully',
+  });
+};
+
+const read = async (req, res) => {
+  const purchase = await purchaseService.get(parseInt(req.params.id, 10));
+  if (!purchase) {
+    return res
+      .status(404)
+      .json({ success: false, result: null, message: 'Purchase not found' });
+  }
+  return res.status(200).json({
+    success: true,
+    result: addId(purchase),
+    message: 'Purchase retrieved successfully',
+  });
+};
+
 const create = async (req, res) => {
   const purchase = await purchaseService.create(req.body);
   return res.status(200).json({
@@ -10,4 +33,35 @@ const create = async (req, res) => {
   });
 };
 
-module.exports = { create };
+const update = async (req, res) => {
+  const purchase = await purchaseService.update(
+    parseInt(req.params.id, 10),
+    req.body
+  );
+  if (!purchase) {
+    return res
+      .status(404)
+      .json({ success: false, result: null, message: 'Purchase not found' });
+  }
+  return res.status(200).json({
+    success: true,
+    result: addId(purchase),
+    message: 'Purchase updated successfully',
+  });
+};
+
+const remove = async (req, res) => {
+  const purchase = await purchaseService.remove(parseInt(req.params.id, 10));
+  if (!purchase) {
+    return res
+      .status(404)
+      .json({ success: false, result: null, message: 'Purchase not found' });
+  }
+  return res.status(200).json({
+    success: true,
+    result: addId(purchase),
+    message: 'Purchase deleted successfully',
+  });
+};
+
+module.exports = { list, read, create, update, delete: remove };

--- a/backend/src/routes/masterDataRoutes.js
+++ b/backend/src/routes/masterDataRoutes.js
@@ -33,7 +33,14 @@ router
 
 router
   .route('/purchases')
+  .get(rbac(['owner', 'manager']), catchErrors(purchaseController.list))
   .post(rbac(['owner', 'manager']), catchErrors(purchaseController.create));
+
+router
+  .route('/purchases/:id')
+  .get(rbac(['owner', 'manager']), catchErrors(purchaseController.read))
+  .patch(rbac(['owner', 'manager']), catchErrors(purchaseController.update))
+  .delete(rbac(['owner', 'manager']), catchErrors(purchaseController.delete));
 
 router
   .route('/stock-ledger')

--- a/backend/src/services/purchaseService.js
+++ b/backend/src/services/purchaseService.js
@@ -1,8 +1,19 @@
 const { AppDataSource } = require('@/typeorm-data-source');
-const { increaseStock } = require('@/utils/stock');
+const { increaseStock, decreaseStock } = require('@/utils/stock');
 
 const purchaseRepository = AppDataSource.getRepository('Purchase');
 const itemRepository = AppDataSource.getRepository('PurchaseItem');
+
+const list = async () => {
+  return purchaseRepository.find();
+};
+
+const get = async (id) => {
+  const purchase = await purchaseRepository.findOne({ where: { id } });
+  if (!purchase) return null;
+  const items = await itemRepository.find({ where: { purchase: id } });
+  return { ...purchase, items };
+};
 
 const create = async (data) => {
   const { supplier, date, items = [], notes } = data;
@@ -32,4 +43,69 @@ const create = async (data) => {
   return purchase;
 };
 
-module.exports = { create };
+const update = async (id, data) => {
+  const purchase = await purchaseRepository.findOne({ where: { id } });
+  if (!purchase) return null;
+
+  const existingItems = await itemRepository.find({ where: { purchase: id } });
+  for (const item of existingItems) {
+    await decreaseStock({
+      productId: item.product,
+      quantity: item.quantity,
+      refId: id,
+      type: 'PURCHASE',
+    });
+  }
+  await itemRepository.delete({ purchase: id });
+
+  const { supplier, date, items = [], notes } = data;
+  const total = items.reduce((sum, i) => sum + i.quantity * i.cost, 0);
+  const merged = purchaseRepository.merge(purchase, {
+    supplier,
+    date,
+    total,
+    notes,
+  });
+  await purchaseRepository.save(merged);
+
+  for (const item of items) {
+    const entity = itemRepository.create({
+      purchase: id,
+      product: item.product,
+      quantity: item.quantity,
+      cost: item.cost,
+      total: item.quantity * item.cost,
+    });
+    await itemRepository.save(entity);
+    await increaseStock({
+      productId: item.product,
+      quantity: item.quantity,
+      cost: item.cost,
+      refId: id,
+      type: 'PURCHASE',
+    });
+  }
+
+  return merged;
+};
+
+const remove = async (id) => {
+  const purchase = await purchaseRepository.findOne({ where: { id } });
+  if (!purchase) return null;
+
+  const items = await itemRepository.find({ where: { purchase: id } });
+  for (const item of items) {
+    await decreaseStock({
+      productId: item.product,
+      quantity: item.quantity,
+      refId: id,
+      type: 'PURCHASE',
+    });
+  }
+
+  await itemRepository.delete({ purchase: id });
+  await purchaseRepository.delete(id);
+  return purchase;
+};
+
+module.exports = { list, get, create, update, remove };


### PR DESCRIPTION
## Summary
- add list/read/update/delete handlers in purchase controller
- implement purchase service CRUD with stock adjustments
- expose GET, PATCH, and DELETE purchase routes

## Testing
- `npm test` (fails: missing script)
- `curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8888/api/purchases`
- `curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8888/api/purchases/2`
- `curl -s -X PATCH http://localhost:8888/api/purchases/2 -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"supplier":1,"date":"2025-08-24","items":[{"product":1,"quantity":3,"cost":5}],"notes":"updated purchase"}'`
- `curl -s -X DELETE http://localhost:8888/api/purchases/2 -H "Authorization: Bearer $TOKEN"`


------
https://chatgpt.com/codex/tasks/task_e_68aafdc178d48333948495c93db852cc