### PR TITLE
feat(frontend): add reusable API service

### DIFF
--- a/frontend/src/components/AutoCompleteAsync/index.jsx
+++ b/frontend/src/components/AutoCompleteAsync/index.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 
-import { request } from '@/request';
+import api from '@/services/api';
 import useOnFetch from '@/hooks/useOnFetch';
 import useDebounce from '@/hooks/useDebounce';
 import { useNavigate } from 'react-router-dom';
@@ -62,7 +62,7 @@ export default function AutoCompleteAsync({
   );
 
   const asyncSearch = async (options) => {
-    return await request.search({ entity, options });
+    return await api.search({ entity, options });
   };
 
   let { onFetch, result, isSuccess, isLoading } = useOnFetch();

--- a/frontend/src/components/MultiStepSelectAsync/index.jsx
+++ b/frontend/src/components/MultiStepSelectAsync/index.jsx
@@ -1,16 +1,16 @@
 import { useState, useEffect } from 'react';
 import { Select, Space } from 'antd';
-import { request } from '@/request';
+import api from '@/services/api';
 import errorHandler from '@/request/errorHandler';
 
 const { Option } = Select;
 
 const asyncList = (entity) => {
-  return request.list({ entity });
+  return api.list({ entity });
 };
 
 const asyncFilter = (entity, options) => {
-  return request.filter({ entity, options });
+  return api.filter({ entity, options });
 };
 
 const MultiStepSelectAsync = ({

--- a/frontend/src/components/SelectAsync/index.jsx
+++ b/frontend/src/components/SelectAsync/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { request } from '@/request';
+import api from '@/services/api';
 import useFetch from '@/hooks/useFetch';
 import { Select, Tag } from 'antd';
 import { useNavigate } from 'react-router-dom';
@@ -25,7 +25,7 @@ const SelectAsync = ({
   const navigate = useNavigate();
 
   const asyncList = () => {
-    return request.list({ entity });
+    return api.list({ entity });
   };
   const { result, isLoading: fetchIsLoading, isSuccess } = useFetch(asyncList);
   useEffect(() => {

--- a/frontend/src/modules/AnalyticsModule/index.jsx
+++ b/frontend/src/modules/AnalyticsModule/index.jsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
 import { Card } from 'antd';
 import useLanguage from '@/locale/useLanguage';
-import { request } from '@/request';
+import api from '@/services/api';
 
 export default function AnalyticsModule() {
   const translate = useLanguage();
   const [data, setData] = useState(null);
 
   useEffect(() => {
-    request.get({ entity: '/reports/analytics' }).then((res) => setData(res));
+    api.get({ entity: '/reports/analytics' }).then((res) => setData(res));
   }, []);
 
   return (

--- a/frontend/src/modules/DashboardModule/components/RecentTable/index.jsx
+++ b/frontend/src/modules/DashboardModule/components/RecentTable/index.jsx
@@ -1,6 +1,6 @@
 import { Dropdown, Table } from 'antd';
 
-import { request } from '@/request';
+import api from '@/services/api';
 import useFetch from '@/hooks/useFetch';
 
 import { EllipsisOutlined, EyeOutlined, EditOutlined, FilePdfOutlined } from '@ant-design/icons';
@@ -85,7 +85,7 @@ export default function RecentTable({ ...props }) {
   ];
 
   const asyncList = () => {
-    return request.list({ entity });
+    return api.list({ entity });
   };
   const { result, isLoading, isSuccess } = useFetch(asyncList);
   const firstFiveItems = () => {

--- a/frontend/src/modules/DashboardModule/index.jsx
+++ b/frontend/src/modules/DashboardModule/index.jsx
@@ -5,7 +5,7 @@ import useLanguage from '@/locale/useLanguage';
 
 import { useMoney } from '@/settings';
 
-import { request } from '@/request';
+import api from '@/services/api';
 import useFetch from '@/hooks/useFetch';
 import useOnFetch from '@/hooks/useOnFetch';
 
@@ -24,7 +24,7 @@ export default function DashboardModule() {
   const money_format_settings = useSelector(selectMoneyFormat);
 
   const getStatsData = async ({ entity, currency }) => {
-    return await request.summary({
+    return await api.summary({
       entity,
       options: { currency },
     });
@@ -45,7 +45,7 @@ export default function DashboardModule() {
   } = useOnFetch();
 
   const { result: clientResult, isLoading: clientLoading } = useFetch(() =>
-    request.summary({ entity: 'client' })
+    api.summary({ entity: 'client' })
   );
 
   useEffect(() => {

--- a/frontend/src/modules/ErpPanelModule/ReadItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/ReadItem.jsx
@@ -14,7 +14,7 @@ import {
 import { useSelector, useDispatch } from 'react-redux';
 import useLanguage from '@/locale/useLanguage';
 import { erp } from '@/redux/erp/actions';
-import request from '@/request/request';
+import api from '@/services/api';
 
 import { generate as uniqueId } from 'shortid';
 
@@ -122,7 +122,7 @@ export default function ReadItem({ config, selectedItem, onConvert }) {
     const loadClient = async () => {
       if (currentErp?.client) {
         if (typeof currentErp.client === 'number') {
-          const data = await request.read({ entity: 'client', id: currentErp.client });
+          const data = await api.read({ entity: 'client', id: currentErp.client });
           if (data.success) {
             setClient(data.result);
           }

--- a/frontend/src/modules/PaymentModule/ReadPaymentModule/components/ReadItem.jsx
+++ b/frontend/src/modules/PaymentModule/ReadPaymentModule/components/ReadItem.jsx
@@ -13,7 +13,7 @@ import {
 import { useSelector, useDispatch } from 'react-redux';
 import { erp } from '@/redux/erp/actions';
 import useLanguage from '@/locale/useLanguage';
-import request from '@/request/request';
+import api from '@/services/api';
 
 import { generate as uniqueId } from 'shortid';
 
@@ -69,7 +69,7 @@ export default function ReadItem({ config, selectedItem }) {
     const loadClient = async () => {
       if (currentErp?.client) {
         if (typeof currentErp.client === 'number') {
-          const data = await request.read({ entity: 'client', id: currentErp.client });
+          const data = await api.read({ entity: 'client', id: currentErp.client });
           if (data.success) {
             setClient(data.result);
           }

--- a/frontend/src/modules/ProfileModule/components/PasswordModal.jsx
+++ b/frontend/src/modules/ProfileModule/components/PasswordModal.jsx
@@ -1,6 +1,6 @@
 import { useProfileContext } from '@/context/profileContext';
 import useOnFetch from '@/hooks/useOnFetch';
-import { request } from '@/request';
+import api from '@/services/api';
 import { Form, Input, Modal } from 'antd';
 
 import useLanguage from '@/locale/useLanguage';
@@ -20,7 +20,7 @@ const PasswordModal = () => {
   const handelSubmit = (fieldsValue) => {
     const entity = 'admin/profile/password/';
     const updateFn = async () => {
-      return await request.patch({ entity, jsonData: fieldsValue });
+      return await api.patch({ entity, jsonData: fieldsValue });
     };
     const callback = updateFn();
     onFetch(callback);

--- a/frontend/src/modules/QuoteModule/ReadQuoteModule/index.jsx
+++ b/frontend/src/modules/QuoteModule/ReadQuoteModule/index.jsx
@@ -4,7 +4,7 @@ import ReadItem from '@/modules/ErpPanelModule/ReadItem';
 
 import PageLoader from '@/components/PageLoader';
 import { erp } from '@/redux/erp/actions';
-import request from '@/request/request';
+import api from '@/services/api';
 
 import { selectReadItem } from '@/redux/erp/selectors';
 import { useLayoutEffect } from 'react';
@@ -17,7 +17,7 @@ export default function ReadQuoteModule({ config }) {
   const { id } = useParams();
 
   const handleConvert = async () => {
-    const data = await request.convert({ entity: 'quotes', id });
+    const data = await api.convert({ entity: 'quotes', id });
     if (data.success) {
       navigate(`/invoice/read/${data.result.id}`);
     }

--- a/frontend/src/modules/ReportModule/index.jsx
+++ b/frontend/src/modules/ReportModule/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Card, Table } from 'antd';
 import useLanguage from '@/locale/useLanguage';
-import { request } from '@/request';
+import api from '@/services/api';
 
 export default function ReportModule() {
   const translate = useLanguage();
@@ -9,8 +9,8 @@ export default function ReportModule() {
   const [aging, setAging] = useState(null);
 
   useEffect(() => {
-    request.get({ entity: '/reports/summary' }).then((res) => setSummary(res));
-    request.get({ entity: '/reports/ar-aging' }).then((res) => setAging(res));
+    api.get({ entity: '/reports/summary' }).then((res) => setSummary(res));
+    api.get({ entity: '/reports/ar-aging' }).then((res) => setAging(res));
   }, []);
 
   const agingData = aging

--- a/frontend/src/pages/ForgetPassword.jsx
+++ b/frontend/src/pages/ForgetPassword.jsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Form, Result, Button } from 'antd';
 import useOnFetch from '@/hooks/useOnFetch';
-import { request } from '@/request';
+import api from '@/services/api';
 
 import ForgetPasswordForm from '@/forms/ForgetPasswordForm';
 
@@ -19,7 +19,7 @@ const ForgetPassword = () => {
   const { onFetch, isSuccess, isLoading } = useOnFetch();
 
   async function postData(data) {
-    return await request.post({ entity: 'forgetpassword', jsonData: data });
+    return await api.post({ entity: 'forgetpassword', jsonData: data });
   }
 
   const onFinish = (values) => {

--- a/frontend/src/redux/adavancedCrud/actions.js
+++ b/frontend/src/redux/adavancedCrud/actions.js
@@ -1,5 +1,5 @@
 import * as actionTypes from './types';
-import { request } from '@/request';
+import api from '@/services/api';
 
 export const erp = {
   resetState: () => (dispatch) => {
@@ -42,7 +42,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.list({ entity, options });
+      let data = await api.list({ entity, options });
 
       if (data.success === true) {
         const result = {
@@ -75,7 +75,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.create({ entity, jsonData });
+      let data = await api.create({ entity, jsonData });
 
       if (data.success === true) {
         dispatch({
@@ -104,7 +104,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.create({ entity, jsonData });
+      let data = await api.create({ entity, jsonData });
 
       if (data.success === true) {
         dispatch({
@@ -133,7 +133,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.read({ entity, id });
+      let data = await api.read({ entity, id });
 
       if (data.success === true) {
         dispatch({
@@ -162,7 +162,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.update({ entity, id, jsonData });
+      let data = await api.update({ entity, id, jsonData });
 
       if (data.success === true) {
         dispatch({
@@ -196,7 +196,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.delete({ entity, id });
+      let data = await api.remove({ entity, id });
 
       if (data.success === true) {
         dispatch({
@@ -222,7 +222,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.search({ entity, options });
+      let data = await api.search({ entity, options });
 
       if (data.success === true) {
         dispatch({
@@ -248,7 +248,7 @@ export const erp = {
         payload: null,
       });
 
-      const data = await request.summary({ entity, options });
+      const data = await api.summary({ entity, options });
 
       if (data.success === true) {
         dispatch({
@@ -274,7 +274,7 @@ export const erp = {
         payload: null,
       });
 
-      const data = await request.mail({ entity, jsonData });
+      const data = await api.mail({ entity, jsonData });
 
       if (data.success === true) {
         dispatch({

--- a/frontend/src/redux/auth/actions.js
+++ b/frontend/src/redux/auth/actions.js
@@ -1,6 +1,6 @@
 import * as actionTypes from './types';
 import * as authService from '@/auth';
-import { request } from '@/request';
+import api from '@/services/api';
 import { notification } from 'antd';
 
 export const login =
@@ -152,7 +152,7 @@ export const logout = () => async (dispatch) => {
 export const updateProfile =
   ({ entity, jsonData }) =>
   async (dispatch) => {
-    let data = await request.updateAndUpload({ entity, id: '', jsonData });
+    let data = await api.updateAndUpload({ entity, id: '', jsonData });
 
     if (data.success === true) {
       dispatch({

--- a/frontend/src/redux/crud/actions.js
+++ b/frontend/src/redux/crud/actions.js
@@ -1,5 +1,5 @@
 import * as actionTypes from './types';
-import { request } from '@/request';
+import api from '@/services/api';
 
 export const crud = {
   resetState:
@@ -44,7 +44,7 @@ export const crud = {
         payload: null,
       });
 
-      let data = await request.list({ entity, options });
+      let data = await api.list({ entity, options });
 
       if (data.success === true) {
         const result = {
@@ -78,9 +78,9 @@ export const crud = {
       });
       let data = null;
       if (withUpload) {
-        data = await request.createAndUpload({ entity, jsonData });
+        data = await api.createAndUpload({ entity, jsonData });
       } else {
-        data = await request.create({ entity, jsonData });
+        data = await api.create({ entity, jsonData });
       }
 
       if (data.success === true) {
@@ -111,7 +111,7 @@ export const crud = {
         payload: null,
       });
 
-      let data = await request.read({ entity, id });
+      let data = await api.read({ entity, id });
 
       if (data.success === true) {
         dispatch({
@@ -143,9 +143,9 @@ export const crud = {
       let data = null;
 
       if (withUpload) {
-        data = await request.updateAndUpload({ entity, id, jsonData });
+        data = await api.updateAndUpload({ entity, id, jsonData });
       } else {
-        data = await request.update({ entity, id, jsonData });
+        data = await api.update({ entity, id, jsonData });
       }
 
       if (data.success === true) {
@@ -180,7 +180,7 @@ export const crud = {
         payload: null,
       });
 
-      let data = await request.delete({ entity, id });
+      let data = await api.remove({ entity, id });
 
       if (data.success === true) {
         dispatch({
@@ -206,7 +206,7 @@ export const crud = {
         payload: null,
       });
 
-      let data = await request.search({ entity, options });
+      let data = await api.search({ entity, options });
 
       if (data.success === true) {
         dispatch({

--- a/frontend/src/redux/erp/actions.js
+++ b/frontend/src/redux/erp/actions.js
@@ -1,5 +1,5 @@
 import * as actionTypes from './types';
-import { request } from '@/request';
+import api from '@/services/api';
 
 export const erp = {
   resetState: () => (dispatch) => {
@@ -42,7 +42,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.list({ entity, options });
+      let data = await api.list({ entity, options });
 
       if (data.success === true) {
         const result = {
@@ -75,7 +75,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.create({ entity, jsonData });
+      let data = await api.create({ entity, jsonData });
 
       if (data.success === true) {
         dispatch({
@@ -104,7 +104,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.create({ entity, jsonData });
+      let data = await api.create({ entity, jsonData });
 
       if (data.success === true) {
         dispatch({
@@ -133,7 +133,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.post({ entity: `invoices/${invoiceId}/payments`, jsonData });
+      let data = await api.post({ entity: `invoices/${invoiceId}/payments`, jsonData });
 
       if (data.success === true) {
         dispatch({
@@ -162,7 +162,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.read({ entity, id });
+      let data = await api.read({ entity, id });
 
       if (data.success === true) {
         dispatch({
@@ -191,7 +191,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.update({ entity, id, jsonData });
+      let data = await api.update({ entity, id, jsonData });
 
       if (data.success === true) {
         dispatch({
@@ -225,7 +225,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.delete({ entity, id });
+      let data = await api.remove({ entity, id });
 
       if (data.success === true) {
         dispatch({
@@ -251,7 +251,7 @@ export const erp = {
         payload: null,
       });
 
-      let data = await request.search({ entity, options });
+      let data = await api.search({ entity, options });
 
       if (data.success === true) {
         dispatch({
@@ -277,7 +277,7 @@ export const erp = {
         payload: null,
       });
 
-      const data = await request.summary({ entity, options });
+      const data = await api.summary({ entity, options });
 
       if (data.success === true) {
         dispatch({
@@ -303,7 +303,7 @@ export const erp = {
         payload: null,
       });
 
-      const data = await request.mail({ entity, jsonData });
+      const data = await api.mail({ entity, jsonData });
 
       if (data.success === true) {
         dispatch({
@@ -324,6 +324,6 @@ export const erp = {
     ({ entity, id }) =>
     async () => {
       const route = entity.endsWith('s') ? entity : `${entity}s`;
-      await request.convert({ entity: route, id });
+      await api.convert({ entity: route, id });
     },
 };

--- a/frontend/src/redux/settings/actions.js
+++ b/frontend/src/redux/settings/actions.js
@@ -1,5 +1,5 @@
 import * as actionTypes from './types';
-import { request } from '@/request';
+import api from '@/services/api';
 
 const dispatchSettingsData = (datas) => {
   const settingsCategory = {};
@@ -34,7 +34,7 @@ export const settingsAction = {
       dispatch({
         type: actionTypes.REQUEST_LOADING,
       });
-      let data = await request.patch({
+      let data = await api.patch({
         entity: entity + '/updateBySettingKey/' + settingKey,
         jsonData,
       });
@@ -44,7 +44,7 @@ export const settingsAction = {
           type: actionTypes.REQUEST_LOADING,
         });
 
-        let data = await request.listAll({ entity });
+        let data = await api.listAll({ entity });
 
         if (data.success === true) {
           const payload = dispatchSettingsData(data.result);
@@ -74,7 +74,7 @@ export const settingsAction = {
       dispatch({
         type: actionTypes.REQUEST_LOADING,
       });
-      let data = await request.patch({
+      let data = await api.patch({
         entity: entity + '/updateManySetting',
         jsonData,
       });
@@ -84,7 +84,7 @@ export const settingsAction = {
           type: actionTypes.REQUEST_LOADING,
         });
 
-        let data = await request.listAll({ entity });
+        let data = await api.listAll({ entity });
 
         if (data.success === true) {
           const payload = dispatchSettingsData(data.result);
@@ -115,7 +115,7 @@ export const settingsAction = {
         type: actionTypes.REQUEST_LOADING,
       });
 
-      let data = await request.listAll({ entity });
+      let data = await api.listAll({ entity });
 
       if (data.success === true) {
         const payload = dispatchSettingsData(data.result);
@@ -138,7 +138,7 @@ export const settingsAction = {
         type: actionTypes.REQUEST_LOADING,
       });
 
-      let data = await request.upload({
+      let data = await api.upload({
         entity: entity,
         id: settingKey,
         jsonData,
@@ -149,7 +149,7 @@ export const settingsAction = {
           type: actionTypes.REQUEST_LOADING,
         });
 
-        let data = await request.listAll({ entity });
+        let data = await api.listAll({ entity });
 
         if (data.success === true) {
           const payload = dispatchSettingsData(data.result);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,281 @@
+import axios from 'axios';
+import http from '@/request/axios';
+import successHandler from '@/request/successHandler';
+
+export async function create({ entity, jsonData }) {
+  try {
+    const response = await http.post(entity + '/create', jsonData);
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function createAndUpload({ entity, jsonData }) {
+  try {
+    const response = await http.post(entity + '/create', jsonData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function read({ entity, id }) {
+  try {
+    const response = await http.get(entity + '/read/' + id);
+    successHandler(response, {
+      notifyOnSuccess: false,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function update({ entity, id, jsonData }) {
+  try {
+    const response = await http.patch(entity + '/update/' + id, jsonData);
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function updateAndUpload({ entity, id, jsonData }) {
+  try {
+    const response = await http.patch(entity + '/update/' + id, jsonData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function remove({ entity, id }) {
+  try {
+    const response = await http.delete(entity + '/delete/' + id);
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function filter({ entity, options = {} }) {
+  try {
+    let filter = options.filter ? 'filter=' + options.filter : '';
+    let equal = options.equal ? '&equal=' + options.equal : '';
+    let query = `?${filter}${equal}`;
+    const response = await http.get(entity + '/filter' + query);
+    successHandler(response, {
+      notifyOnSuccess: false,
+      notifyOnFailed: false,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function search({ entity, options = {} }) {
+  try {
+    let query = '?';
+    for (var key in options) {
+      query += key + '=' + options[key] + '&';
+    }
+    query = query.slice(0, -1);
+    const response = await http.get(entity + '/search' + query);
+    successHandler(response, {
+      notifyOnSuccess: false,
+      notifyOnFailed: false,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function list({ entity, options = {} }) {
+  try {
+    let query = '?';
+    for (var key in options) {
+      query += key + '=' + options[key] + '&';
+    }
+    query = query.slice(0, -1);
+    const response = await http.get(entity + '/list' + query);
+    successHandler(response, {
+      notifyOnSuccess: false,
+      notifyOnFailed: false,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function listAll({ entity, options = {} }) {
+  try {
+    let query = '?';
+    for (var key in options) {
+      query += key + '=' + options[key] + '&';
+    }
+    query = query.slice(0, -1);
+    const response = await http.get(entity + '/listAll' + query);
+    successHandler(response, {
+      notifyOnSuccess: false,
+      notifyOnFailed: false,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function post({ entity, jsonData }) {
+  try {
+    const response = await http.post(entity, jsonData);
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function get({ entity }) {
+  try {
+    const response = await http.get(entity);
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function patch({ entity, jsonData }) {
+  try {
+    const response = await http.patch(entity, jsonData);
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function upload({ entity, id, jsonData }) {
+  try {
+    const response = await http.patch(entity + '/upload/' + id, jsonData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export function source() {
+  const CancelToken = axios.CancelToken;
+  const source = CancelToken.source();
+  return source;
+}
+
+export async function summary({ entity, options = {} }) {
+  try {
+    let query = '?';
+    for (var key in options) {
+      query += key + '=' + options[key] + '&';
+    }
+    query = query.slice(0, -1);
+    const response = await http.get(entity + '/summary' + query);
+    successHandler(response, {
+      notifyOnSuccess: false,
+      notifyOnFailed: false,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function mail({ entity, jsonData }) {
+  try {
+    const response = await http.post(entity + '/mail/', jsonData);
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function convert({ entity, id }) {
+  try {
+    const response = await http.post(`${entity}/${id}/convert`, {});
+    successHandler(response, {
+      notifyOnSuccess: true,
+      notifyOnFailed: true,
+    });
+    return response.data;
+  } catch (error) {
+    return error;
+  }
+}
+
+const api = {
+  create,
+  createAndUpload,
+  read,
+  update,
+  updateAndUpload,
+  remove,
+  filter,
+  search,
+  list,
+  listAll,
+  post,
+  get,
+  patch,
+  upload,
+  source,
+  summary,
+  mail,
+  convert,
+};
+
+export default api;
+


### PR DESCRIPTION
## Summary
- add generic api service wrapping axios
- refactor modules to use shared api functions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: module is not defined in .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aafe49c2d48333be8f8b9bddd3d2ec