### PR TITLE
feat: add purchase list and details with summary

### DIFF
--- a/frontend/src/modules/PurchaseModule/CreatePurchaseModule/index.jsx
+++ b/frontend/src/modules/PurchaseModule/CreatePurchaseModule/index.jsx
@@ -1,0 +1,19 @@
+import PurchaseForm from '../PurchaseForm';
+
+const CreatePurchaseModule = () => {
+  const handleSubmit = async (data) => {
+    try {
+      await fetch('/api/purchases', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return <PurchaseForm onSubmit={handleSubmit} />;
+};
+
+export default CreatePurchaseModule;

--- a/frontend/src/modules/PurchaseModule/PurchaseDataTableModule/index.jsx
+++ b/frontend/src/modules/PurchaseModule/PurchaseDataTableModule/index.jsx
@@ -1,0 +1,10 @@
+import { ErpLayout } from '@/layout';
+import ErpPanel from '@/modules/ErpPanelModule';
+
+export default function PurchaseDataTableModule({ config }) {
+  return (
+    <ErpLayout>
+      <ErpPanel config={config}></ErpPanel>
+    </ErpLayout>
+  );
+}

--- a/frontend/src/modules/PurchaseModule/PurchaseForm.jsx
+++ b/frontend/src/modules/PurchaseModule/PurchaseForm.jsx
@@ -1,11 +1,35 @@
 import React, { useState } from 'react';
 
+const emptyItem = { product: '', quantity: 0, cost: 0 };
+
 const PurchaseForm = ({ onSubmit }) => {
-  const [form, setForm] = useState({ product: '', quantity: 0, cost: 0 });
+  const [form, setForm] = useState({
+    supplier: '',
+    date: '',
+    note: '',
+    items: [emptyItem],
+  });
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleItemChange = (index, field, value) => {
+    setForm((f) => {
+      const items = f.items.map((item, idx) =>
+        idx === index ? { ...item, [field]: value } : item
+      );
+      return { ...f, items };
+    });
+  };
+
+  const addItem = () => {
+    setForm((f) => ({ ...f, items: [...f.items, { ...emptyItem }] }));
+  };
+
+  const removeItem = (index) => {
+    setForm((f) => ({ ...f, items: f.items.filter((_, idx) => idx !== index) }));
   };
 
   const handleSubmit = (e) => {
@@ -16,16 +40,46 @@ const PurchaseForm = ({ onSubmit }) => {
   return (
     <form onSubmit={handleSubmit}>
       <div>
-        <label>Product ID</label>
-        <input name="product" value={form.product} onChange={handleChange} />
+        <label>Supplier ID</label>
+        <input name="supplier" value={form.supplier} onChange={handleChange} />
       </div>
       <div>
-        <label>Quantity</label>
-        <input name="quantity" type="number" value={form.quantity} onChange={handleChange} />
+        <label>Date</label>
+        <input type="date" name="date" value={form.date} onChange={handleChange} />
       </div>
       <div>
-        <label>Cost</label>
-        <input name="cost" type="number" value={form.cost} onChange={handleChange} />
+        <label>Notes</label>
+        <textarea name="note" value={form.note} onChange={handleChange} />
+      </div>
+      <div>
+        <h4>Items</h4>
+        {form.items.map((item, index) => (
+          <div key={index} style={{ marginBottom: '10px' }}>
+            <input
+              placeholder="Product ID"
+              value={item.product}
+              onChange={(e) => handleItemChange(index, 'product', e.target.value)}
+            />
+            <input
+              type="number"
+              placeholder="Qty"
+              value={item.quantity}
+              onChange={(e) => handleItemChange(index, 'quantity', e.target.value)}
+            />
+            <input
+              type="number"
+              placeholder="Cost"
+              value={item.cost}
+              onChange={(e) => handleItemChange(index, 'cost', e.target.value)}
+            />
+            <button type="button" onClick={() => removeItem(index)}>
+              Remove
+            </button>
+          </div>
+        ))}
+        <button type="button" onClick={addItem}>
+          Add Item
+        </button>
       </div>
       <button type="submit">Save Purchase</button>
     </form>

--- a/frontend/src/modules/PurchaseModule/ReadPurchaseModule/index.jsx
+++ b/frontend/src/modules/PurchaseModule/ReadPurchaseModule/index.jsx
@@ -1,0 +1,39 @@
+import NotFound from '@/components/NotFound';
+import { ErpLayout } from '@/layout';
+import ReadItem from '@/modules/ErpPanelModule/ReadItem';
+
+import PageLoader from '@/components/PageLoader';
+import { erp } from '@/redux/erp/actions';
+import { selectReadItem } from '@/redux/erp/selectors';
+import { useLayoutEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useParams } from 'react-router-dom';
+
+export default function ReadPurchaseModule({ config }) {
+  const dispatch = useDispatch();
+  const { id } = useParams();
+
+  useLayoutEffect(() => {
+    dispatch(erp.read({ entity: config.entity, id }));
+  }, [id]);
+
+  const { result: currentResult, isSuccess, isLoading = true } = useSelector(selectReadItem);
+
+  if (isLoading) {
+    return (
+      <ErpLayout>
+        <PageLoader />
+      </ErpLayout>
+    );
+  } else
+    return (
+      <ErpLayout>
+        {isSuccess ? (
+          <ReadItem config={config} selectedItem={currentResult} />
+        ) : (
+          <NotFound entity={config.entity} />
+        )}
+      </ErpLayout>
+    );
+}

--- a/frontend/src/modules/PurchaseModule/index.jsx
+++ b/frontend/src/modules/PurchaseModule/index.jsx
@@ -1,20 +1,4 @@
-import React from 'react';
-import PurchaseForm from './PurchaseForm';
-
-const PurchaseModule = () => {
-  const handleSubmit = async (data) => {
-    try {
-      await fetch('/api/purchases', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ items: [data] }),
-      });
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
-  return <PurchaseForm onSubmit={handleSubmit} />;
-};
-
-export default PurchaseModule;
+export { default as PurchaseDataTableModule } from './PurchaseDataTableModule';
+export { default as CreatePurchaseModule } from './CreatePurchaseModule';
+export { default as ReadPurchaseModule } from './ReadPurchaseModule';
+export { default as PurchaseForm } from './PurchaseForm';

--- a/frontend/src/pages/Purchase/PurchaseCreate.jsx
+++ b/frontend/src/pages/Purchase/PurchaseCreate.jsx
@@ -1,0 +1,5 @@
+import { CreatePurchaseModule } from '@/modules/PurchaseModule';
+
+export default function PurchaseCreate() {
+  return <CreatePurchaseModule />;
+}

--- a/frontend/src/pages/Purchase/PurchaseRead.jsx
+++ b/frontend/src/pages/Purchase/PurchaseRead.jsx
@@ -1,0 +1,15 @@
+import useLanguage from '@/locale/useLanguage';
+import { ReadPurchaseModule } from '@/modules/PurchaseModule';
+
+export default function PurchaseRead() {
+  const entity = 'purchase';
+  const translate = useLanguage();
+  const Labels = {
+    PANEL_TITLE: translate('purchase'),
+    DATATABLE_TITLE: translate('purchase_list'),
+    ADD_NEW_ENTITY: translate('add_new_purchase'),
+    ENTITY_NAME: translate('purchase'),
+  };
+  const configPage = { entity, ...Labels };
+  return <ReadPurchaseModule config={configPage} />;
+}

--- a/frontend/src/pages/Purchase/index.jsx
+++ b/frontend/src/pages/Purchase/index.jsx
@@ -1,5 +1,75 @@
-import { ErpLayout } from '@/layout';
+import dayjs from 'dayjs';
+import useLanguage from '@/locale/useLanguage';
+import { useDate } from '@/settings';
+import { PurchaseDataTableModule } from '@/modules/PurchaseModule';
+import { useEffect, useState } from 'react';
+import { request } from '@/request';
 
 export default function Purchase() {
-  return <ErpLayout>Purchasing module</ErpLayout>;
+  const translate = useLanguage();
+  const { dateFormat } = useDate();
+  const [summary, setSummary] = useState(null);
+  const [period, setPeriod] = useState({ start: '', end: '' });
+
+  const fetchSummary = () => {
+    request
+      .summary({ entity: 'purchase', options: { startDate: period.start, endDate: period.end } })
+      .then((res) => setSummary(res.result));
+  };
+
+  useEffect(() => {
+    fetchSummary();
+  }, []);
+
+  const dataTableColumns = [
+    { title: translate('ID'), dataIndex: 'id' },
+    { title: translate('Supplier'), dataIndex: ['supplier', 'name'] },
+    {
+      title: translate('Date'),
+      dataIndex: 'date',
+      render: (date) => dayjs(date).format(dateFormat),
+    },
+    { title: translate('Total'), dataIndex: 'total' },
+  ];
+
+  const Labels = {
+    PANEL_TITLE: translate('purchase'),
+    DATATABLE_TITLE: translate('purchase_list'),
+    ADD_NEW_ENTITY: translate('add_new_purchase'),
+    ENTITY_NAME: translate('purchase'),
+  };
+
+  const entity = 'purchase';
+  const config = { entity, ...Labels, dataTableColumns };
+
+  return (
+    <div>
+      <div className="whiteBox shadow" style={{ padding: '15px', marginBottom: '20px' }}>
+        <div>
+          <label>{translate('Start Date')}</label>
+          <input
+            type="date"
+            value={period.start}
+            onChange={(e) => setPeriod({ ...period, start: e.target.value })}
+          />
+          <label style={{ marginLeft: '10px' }}>{translate('End Date')}</label>
+          <input
+            type="date"
+            value={period.end}
+            onChange={(e) => setPeriod({ ...period, end: e.target.value })}
+          />
+          <button style={{ marginLeft: '10px' }} onClick={fetchSummary}>
+            {translate('Load')}
+          </button>
+        </div>
+        {summary && (
+          <div style={{ marginTop: '10px' }}>
+            <strong>{translate('Total')}:</strong> {summary.total} |{' '}
+            <strong>{translate('Count')}:</strong> {summary.count}
+          </div>
+        )}
+      </div>
+      <PurchaseDataTableModule config={config} />
+    </div>
+  );
 }

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -24,7 +24,9 @@ const PaymentRead = lazy(() => import('@/pages/Payment/PaymentRead'));
 const PaymentUpdate = lazy(() => import('@/pages/Payment/PaymentUpdate'));
 const DeliveryNote = lazy(() => import('@/pages/DeliveryNote'));
 const Expense = lazy(() => import('@/pages/Expense'));
-const Purchase = lazy(() => import('@/pages/Purchase'));
+
+const PurchaseCreate = lazy(() => import('@/pages/Purchase/PurchaseCreate'));
+const PurchaseRead = lazy(() => import('@/pages/Purchase/PurchaseRead'));
 const Reports = lazy(() => import('@/pages/Reports'));
 const Analytics = lazy(() => import('@/pages/Analytics'));
 
@@ -51,6 +53,8 @@ let routes = {
   ],
   purchasing: [
     { path: '/purchase', element: <Purchase /> },
+    { path: '/purchase/create', element: <PurchaseCreate /> },
+    { path: '/purchase/read/:id', element: <PurchaseRead /> },
   ],
   delivery: [
     { path: '/deliverynote', element: <DeliveryNote /> },
@@ -81,6 +85,9 @@ let routes = {
     { path: '/payment', element: <Payment /> },
     { path: '/payment/read/:id', element: <PaymentRead /> },
     { path: '/payment/update/:id', element: <PaymentUpdate /> },
+    { path: '/purchase', element: <Purchase /> },
+    { path: '/purchase/create', element: <PurchaseCreate /> },
+    { path: '/purchase/read/:id', element: <PurchaseRead /> },
     { path: '/profile', element: <Profile /> },
     { path: '*', element: <NotFound /> },
     {


### PR DESCRIPTION
## Summary
- add PurchaseDataTableModule and ReadPurchaseModule
- expand PurchaseForm with supplier, date, notes, and multiple items
- show purchase totals per period and wire up purchase routes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aafe4f64408333a7afd67be681d0bc