### PR TITLE
feat(deliverynote): add forms and pdf actions

### DIFF
--- a/frontend/src/modules/DeliveryNoteModule/CreateDeliveryNoteModule/index.jsx
+++ b/frontend/src/modules/DeliveryNoteModule/CreateDeliveryNoteModule/index.jsx
@@ -1,0 +1,11 @@
+import { ErpLayout } from '@/layout';
+import CreateItem from '@/modules/ErpPanelModule/CreateItem';
+import DeliveryNoteForm from '@/modules/DeliveryNoteModule/Forms/DeliveryNoteForm';
+
+export default function CreateDeliveryNoteModule({ config }) {
+  return (
+    <ErpLayout>
+      <CreateItem config={config} CreateForm={DeliveryNoteForm} />
+    </ErpLayout>
+  );
+}

--- a/frontend/src/modules/DeliveryNoteModule/Forms/DeliveryNoteForm.jsx
+++ b/frontend/src/modules/DeliveryNoteModule/Forms/DeliveryNoteForm.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef } from 'react';
+import dayjs from 'dayjs';
+import { Form, Input, InputNumber, Button, Row, Col, Divider, DatePicker } from 'antd';
+import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import AutoCompleteAsync from '@/components/AutoCompleteAsync';
+import useLanguage from '@/locale/useLanguage';
+import { useDate } from '@/settings';
+
+export default function DeliveryNoteForm({ current = null }) {
+  const translate = useLanguage();
+  const { dateFormat } = useDate();
+  const addField = useRef(null);
+
+  useEffect(() => {
+    if (!current) {
+      addField.current?.click();
+    }
+  }, []);
+
+  return (
+    <>
+      <Row gutter={[12, 0]}>
+        <Col className="gutter-row" span={8}>
+          <Form.Item
+            name="client"
+            label={translate('Client')}
+            rules={[{ required: true }]}
+          >
+            <AutoCompleteAsync
+              entity={'client'}
+              displayLabels={['name']}
+              searchFields={'name'}
+              redirectLabel={translate('Add New Client')}
+              withRedirect
+              urlToRedirect={'/customer'}
+            />
+          </Form.Item>
+        </Col>
+        <Col className="gutter-row" span={8}>
+          <Form.Item
+            name="date"
+            label={translate('Date')}
+            initialValue={dayjs()}
+            rules={[{ required: true }]}
+          >
+            <DatePicker style={{ width: '100%' }} format={dateFormat} />
+          </Form.Item>
+        </Col>
+        <Col className="gutter-row" span={8}>
+          <Form.Item name="notes" label={translate('Note')}>
+            <Input />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Divider dashed />
+      <Row gutter={[12, 12]}>
+        <Col className="gutter-row" span={12}>
+          <p>{translate('Product')}</p>
+        </Col>
+        <Col className="gutter-row" span={8}>
+          <p>{translate('Quantity')}</p>
+        </Col>
+      </Row>
+      <Form.List name="items">
+        {(fields, { add, remove }) => (
+          <>
+            {fields.map((field) => (
+              <Row key={field.key} gutter={[12, 12]} style={{ position: 'relative' }}>
+                <Col className="gutter-row" span={12}>
+                  <Form.Item
+                    name={[field.name, 'product']}
+                    rules={[{ required: true }]}
+                  >
+                    <AutoCompleteAsync
+                      entity={'product'}
+                      displayLabels={['name']}
+                      searchFields={'name'}
+                      redirectLabel={translate('Add New Product')}
+                      withRedirect
+                      urlToRedirect={'/product'}
+                    />
+                  </Form.Item>
+                </Col>
+                <Col className="gutter-row" span={8}>
+                  <Form.Item
+                    name={[field.name, 'quantity']}
+                    rules={[{ required: true }]}
+                  >
+                    <InputNumber min={1} style={{ width: '100%' }} />
+                  </Form.Item>
+                </Col>
+                <Col className="gutter-row" span={4}>
+                  <DeleteOutlined onClick={() => remove(field.name)} />
+                </Col>
+                <Form.Item
+                  name={[field.name, 'price']}
+                  initialValue={0}
+                  style={{ display: 'none' }}
+                >
+                  <InputNumber />
+                </Form.Item>
+              </Row>
+            ))}
+            <Form.Item>
+              <Button
+                type="dashed"
+                onClick={() => add()}
+                block
+                icon={<PlusOutlined />}
+                ref={addField}
+              >
+                {translate('Add field')}
+              </Button>
+            </Form.Item>
+          </>
+        )}
+      </Form.List>
+    </>
+  );
+}
+

--- a/frontend/src/modules/DeliveryNoteModule/ReadDeliveryNoteModule/index.jsx
+++ b/frontend/src/modules/DeliveryNoteModule/ReadDeliveryNoteModule/index.jsx
@@ -1,0 +1,39 @@
+import NotFound from '@/components/NotFound';
+import { ErpLayout } from '@/layout';
+import ReadItem from '@/modules/ErpPanelModule/ReadItem';
+
+import PageLoader from '@/components/PageLoader';
+import { erp } from '@/redux/erp/actions';
+
+import { selectReadItem } from '@/redux/erp/selectors';
+import { useLayoutEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
+
+export default function ReadDeliveryNoteModule({ config }) {
+  const dispatch = useDispatch();
+  const { id } = useParams();
+
+  useLayoutEffect(() => {
+    dispatch(erp.read({ entity: config.entity, id }));
+  }, [id]);
+
+  const { result: currentResult, isSuccess, isLoading = true } = useSelector(selectReadItem);
+
+  if (isLoading) {
+    return (
+      <ErpLayout>
+        <PageLoader />
+      </ErpLayout>
+    );
+  } else
+    return (
+      <ErpLayout>
+        {isSuccess ? (
+          <ReadItem config={config} selectedItem={currentResult} />
+        ) : (
+          <NotFound entity={config.entity} />
+        )}
+      </ErpLayout>
+    );
+}

--- a/frontend/src/modules/DeliveryNoteModule/UpdateDeliveryNoteModule/index.jsx
+++ b/frontend/src/modules/DeliveryNoteModule/UpdateDeliveryNoteModule/index.jsx
@@ -1,0 +1,48 @@
+import NotFound from '@/components/NotFound';
+import { ErpLayout } from '@/layout';
+import UpdateItem from '@/modules/ErpPanelModule/UpdateItem';
+import DeliveryNoteForm from '@/modules/DeliveryNoteModule/Forms/DeliveryNoteForm';
+
+import PageLoader from '@/components/PageLoader';
+
+import { erp } from '@/redux/erp/actions';
+import useLanguage from '@/locale/useLanguage';
+import { selectReadItem } from '@/redux/erp/selectors';
+import { useLayoutEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
+
+export default function UpdateDeliveryNoteModule({ config }) {
+  const dispatch = useDispatch();
+  const { id } = useParams();
+  const translate = useLanguage();
+
+  useLayoutEffect(() => {
+    dispatch(erp.read({ entity: config.entity, id }));
+  }, [id]);
+
+  const { result: currentResult, isSuccess, isLoading = true } = useSelector(selectReadItem);
+
+  useLayoutEffect(() => {
+    if (currentResult) {
+      dispatch(erp.currentAction({ actionType: 'update', data: currentResult }));
+    }
+  }, [currentResult]);
+
+  if (isLoading) {
+    return (
+      <ErpLayout>
+        <PageLoader />
+      </ErpLayout>
+    );
+  } else
+    return (
+      <ErpLayout>
+        {isSuccess ? (
+          <UpdateItem config={config} UpdateForm={DeliveryNoteForm} />
+        ) : (
+          <NotFound entity={translate(config.entity)} />
+        )}
+      </ErpLayout>
+    );
+}

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -93,7 +93,7 @@ export default function DataTable({ config, extra = [] }) {
     navigate(`/${entity}/update/${record._id}`);
   };
   const handleDownload = (record) => {
-    window.open(`${DOWNLOAD_BASE_URL}${entity}/${entity}-${record._id}.pdf`, '_blank');
+    window.open(`${API_BASE_URL}${entity}/${record._id}/download`, '_blank');
   };
 
   const handleDelete = (record) => {
@@ -117,6 +117,7 @@ export default function DataTable({ config, extra = [] }) {
     await fetch(`${API_BASE_URL}${entity}/${record._id}/generateInvoice`, {
       method: 'POST',
     });
+    handelDataTableLoad(pagination);
   };
 
   dataTableColumns = [

--- a/frontend/src/pages/DeliveryNote/DeliveryNoteCreate.jsx
+++ b/frontend/src/pages/DeliveryNote/DeliveryNoteCreate.jsx
@@ -1,0 +1,17 @@
+import useLanguage from '@/locale/useLanguage';
+import CreateDeliveryNoteModule from '@/modules/DeliveryNoteModule/CreateDeliveryNoteModule';
+
+export default function DeliveryNoteCreate() {
+  const translate = useLanguage();
+  const entity = 'deliverynote';
+
+  const Labels = {
+    PANEL_TITLE: translate('deliverynote'),
+    DATATABLE_TITLE: translate('deliverynote_list'),
+    ADD_NEW_ENTITY: translate('add_new_deliverynote'),
+    ENTITY_NAME: translate('deliverynote'),
+  };
+
+  const configPage = { entity, ...Labels };
+  return <CreateDeliveryNoteModule config={configPage} />;
+}

--- a/frontend/src/pages/DeliveryNote/DeliveryNoteRead.jsx
+++ b/frontend/src/pages/DeliveryNote/DeliveryNoteRead.jsx
@@ -1,0 +1,17 @@
+import useLanguage from '@/locale/useLanguage';
+import ReadDeliveryNoteModule from '@/modules/DeliveryNoteModule/ReadDeliveryNoteModule';
+
+export default function DeliveryNoteRead() {
+  const translate = useLanguage();
+  const entity = 'deliverynote';
+
+  const Labels = {
+    PANEL_TITLE: translate('deliverynote'),
+    DATATABLE_TITLE: translate('deliverynote_list'),
+    ADD_NEW_ENTITY: translate('add_new_deliverynote'),
+    ENTITY_NAME: translate('deliverynote'),
+  };
+
+  const configPage = { entity, ...Labels };
+  return <ReadDeliveryNoteModule config={configPage} />;
+}

--- a/frontend/src/pages/DeliveryNote/DeliveryNoteUpdate.jsx
+++ b/frontend/src/pages/DeliveryNote/DeliveryNoteUpdate.jsx
@@ -1,0 +1,17 @@
+import useLanguage from '@/locale/useLanguage';
+import UpdateDeliveryNoteModule from '@/modules/DeliveryNoteModule/UpdateDeliveryNoteModule';
+
+export default function DeliveryNoteUpdate() {
+  const translate = useLanguage();
+  const entity = 'deliverynote';
+
+  const Labels = {
+    PANEL_TITLE: translate('deliverynote'),
+    DATATABLE_TITLE: translate('deliverynote_list'),
+    ADD_NEW_ENTITY: translate('add_new_deliverynote'),
+    ENTITY_NAME: translate('deliverynote'),
+  };
+
+  const configPage = { entity, ...Labels };
+  return <UpdateDeliveryNoteModule config={configPage} />;
+}

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -23,6 +23,9 @@ const Payment = lazy(() => import('@/pages/Payment/index'));
 const PaymentRead = lazy(() => import('@/pages/Payment/PaymentRead'));
 const PaymentUpdate = lazy(() => import('@/pages/Payment/PaymentUpdate'));
 const DeliveryNote = lazy(() => import('@/pages/DeliveryNote'));
+const DeliveryNoteCreate = lazy(() => import('@/pages/DeliveryNote/DeliveryNoteCreate'));
+const DeliveryNoteRead = lazy(() => import('@/pages/DeliveryNote/DeliveryNoteRead'));
+const DeliveryNoteUpdate = lazy(() => import('@/pages/DeliveryNote/DeliveryNoteUpdate'));
 const Expense = lazy(() => import('@/pages/Expense'));
 const Purchase = lazy(() => import('@/pages/Purchase'));
 const Reports = lazy(() => import('@/pages/Reports'));
@@ -156,6 +159,18 @@ let routes = {
     {
       path: '/deliverynote',
       element: <DeliveryNote />,
+    },
+    {
+      path: '/deliverynote/create',
+      element: <DeliveryNoteCreate />,
+    },
+    {
+      path: '/deliverynote/read/:id',
+      element: <DeliveryNoteRead />,
+    },
+    {
+      path: '/deliverynote/update/:id',
+      element: <DeliveryNoteUpdate />,
     },
     {
       path: '/reports',


### PR DESCRIPTION
## Summary
- add create, read and update modules for delivery notes
- enable delivery note PDF download and table actions
- wire delivery note routes into router

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aafe51f46483338cc83a8a16a0e19f