### PR TITLE
feat: add employee page with CRUD support

### DIFF
--- a/frontend/src/modules/EmployeeModule/EmployeeDataTableModule/index.jsx
+++ b/frontend/src/modules/EmployeeModule/EmployeeDataTableModule/index.jsx
@@ -1,0 +1,9 @@
+import CrudModule from '@/modules/CrudModule/CrudModule';
+import EmployeeForm from '@/forms/EmployeeForm';
+
+export default function EmployeeDataTableModule({ config }) {
+  return (
+    <CrudModule createForm={<EmployeeForm />} updateForm={<EmployeeForm />} config={config} />
+  );
+}
+

--- a/frontend/src/pages/Employee/index.jsx
+++ b/frontend/src/pages/Employee/index.jsx
@@ -1,0 +1,37 @@
+import useLanguage from '@/locale/useLanguage';
+import EmployeeDataTableModule from '@/modules/EmployeeModule/EmployeeDataTableModule';
+
+export default function Employee() {
+  const translate = useLanguage();
+  const entity = 'employee';
+
+  const searchConfig = {
+    searchFields: 'name,position',
+  };
+
+  const deleteModalLabels = ['name', 'position'];
+
+  const readColumns = [
+    { title: translate('first name'), dataIndex: 'name' },
+    { title: translate('last name'), dataIndex: 'surname' },
+    { title: translate('Position'), dataIndex: 'position' },
+    { title: translate('Department'), dataIndex: 'department' },
+    { title: translate('email'), dataIndex: 'email' },
+    { title: translate('phone'), dataIndex: 'phone' },
+  ];
+
+  const dataTableColumns = [...readColumns];
+
+  const Labels = {
+    PANEL_TITLE: translate('employee'),
+    DATATABLE_TITLE: translate('employee_list'),
+    ADD_NEW_ENTITY: translate('add_new_employee'),
+    ENTITY_NAME: translate('employee'),
+  };
+
+  const configPage = { entity, ...Labels };
+  const config = { ...configPage, readColumns, dataTableColumns, searchConfig, deleteModalLabels };
+
+  return <EmployeeDataTableModule config={config} />;
+}
+


### PR DESCRIPTION
## Summary
- add EmployeeDataTableModule wrapping CrudModule with EmployeeForm
- create Employee page using EmployeeDataTableModule and search by name or position

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab033a9b1c83339907784d3c27435e