### PR TITLE
Add payroll page with form and monthly summary

### DIFF
--- a/backend/src/controllers/appControllers/payrollController/index.js
+++ b/backend/src/controllers/appControllers/payrollController/index.js
@@ -6,6 +6,7 @@ const repository = AppDataSource.getRepository('Payroll');
 const expenseRepository = AppDataSource.getRepository('Expense');
 
 const methods = createCRUDController(repository);
+const summary = require('./summary');
 
 methods.create = async (req, res) => {
   try {
@@ -31,5 +32,7 @@ methods.create = async (req, res) => {
     return res.status(500).json({ success: false, result: null, message: error.message });
   }
 };
+
+methods.summary = summary;
 
 module.exports = methods;

--- a/backend/src/controllers/appControllers/payrollController/summary.js
+++ b/backend/src/controllers/appControllers/payrollController/summary.js
@@ -1,0 +1,26 @@
+const { AppDataSource } = require('@/typeorm-data-source');
+const repository = AppDataSource.getRepository('Payroll');
+
+const summary = async (req, res) => {
+  try {
+    const qb = repository
+      .createQueryBuilder('payroll')
+      .select("DATE_FORMAT(payroll.date, '%Y-%m-01')", 'month')
+      .addSelect('SUM(payroll.amount)', 'total')
+      .where('payroll.removed = :removed', { removed: false })
+      .groupBy('month')
+      .orderBy('month', 'DESC');
+
+    const data = await qb.getRawMany();
+
+    return res.status(200).json({
+      success: true,
+      result: data,
+      message: 'Successfully fetched payroll totals per month',
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, result: null, message: error.message });
+  }
+};
+
+module.exports = summary;

--- a/frontend/src/modules/PayrollModule/CreatePayrollModule/index.jsx
+++ b/frontend/src/modules/PayrollModule/CreatePayrollModule/index.jsx
@@ -2,7 +2,7 @@ import PayrollForm from '../PayrollForm';
 
 const CreatePayrollModule = () => {
   const handleSubmit = async (data) => {
-    await fetch('/api/payroll', {
+    await fetch('/api/payroll/create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),

--- a/frontend/src/modules/PayrollModule/PayrollForm.jsx
+++ b/frontend/src/modules/PayrollModule/PayrollForm.jsx
@@ -1,35 +1,65 @@
-import React, { useState } from 'react';
+import dayjs from 'dayjs';
+import { Form, Input, InputNumber, Button, DatePicker } from 'antd';
+import SelectAsync from '@/components/SelectAsync';
+import useLanguage from '@/locale/useLanguage';
+import { useDate } from '@/settings';
 
-const PayrollForm = ({ onSubmit }) => {
-  const [form, setForm] = useState({ employee: '', amount: 0, description: '' });
+export default function PayrollForm({ onSubmit }) {
+  const [form] = Form.useForm();
+  const translate = useLanguage();
+  const { dateFormat } = useDate();
 
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setForm((f) => ({ ...f, [name]: value }));
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    onSubmit(form);
+  const handleFinish = (values) => {
+    onSubmit({
+      ...values,
+      date: values.date.format('YYYY-MM-DD'),
+    });
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div>
-        <label>Employee ID</label>
-        <input name="employee" value={form.employee} onChange={handleChange} />
-      </div>
-      <div>
-        <label>Amount</label>
-        <input name="amount" type="number" value={form.amount} onChange={handleChange} />
-      </div>
-      <div>
-        <label>Description</label>
-        <input name="description" value={form.description} onChange={handleChange} />
-      </div>
-      <button type="submit">Save Payroll</button>
-    </form>
-  );
-};
+    <Form form={form} layout="vertical" onFinish={handleFinish}>
+      <Form.Item
+        name="employee"
+        label={translate('Employee')}
+        rules={[{ required: true }]}
+      >
+        <SelectAsync entity="employee" displayLabels={['firstName', 'lastName']} />
+      </Form.Item>
 
-export default PayrollForm;
+      <Form.Item
+        name="amount"
+        label={translate('Amount')}
+        rules={[{ required: true }]}
+      >
+        <InputNumber style={{ width: '100%' }} min={0} />
+      </Form.Item>
+
+      <Form.Item
+        name="date"
+        label={translate('Date')}
+        rules={[{ required: true }]}
+        initialValue={dayjs()}
+      >
+        <DatePicker format={dateFormat} style={{ width: '100%' }} />
+      </Form.Item>
+
+      <Form.Item
+        name="category"
+        label={translate('expense_category')}
+        rules={[{ required: true }]}
+      >
+        <SelectAsync entity="expenseCategory" displayLabels={['name']} />
+      </Form.Item>
+
+      <Form.Item name="description" label={translate('Description')}>
+        <Input />
+      </Form.Item>
+
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          {translate('Save')}
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/frontend/src/pages/Payroll/index.jsx
+++ b/frontend/src/pages/Payroll/index.jsx
@@ -1,0 +1,70 @@
+import dayjs from 'dayjs';
+import { useEffect, useState } from 'react';
+import { Card, Table } from 'antd';
+import { Link } from 'react-router-dom';
+import useLanguage from '@/locale/useLanguage';
+import { useDate } from '@/settings';
+import { PayrollDataTableModule } from '@/modules/PayrollModule';
+import { request } from '@/request';
+
+export default function Payroll() {
+  const translate = useLanguage();
+  const { dateFormat } = useDate();
+  const entity = 'payroll';
+  const [summary, setSummary] = useState([]);
+
+  useEffect(() => {
+    request.summary({ entity }).then((res) => {
+      if (res?.result) {
+        setSummary(res.result);
+      }
+    });
+  }, []);
+
+  const dataTableColumns = [
+    { title: translate('ID'), dataIndex: 'id' },
+    { title: translate('Employee'), dataIndex: 'employee' },
+    { title: translate('Amount'), dataIndex: 'amount' },
+    {
+      title: translate('Date'),
+      dataIndex: 'date',
+      render: (date) => dayjs(date).format(dateFormat),
+    },
+  ];
+
+  const Labels = {
+    PANEL_TITLE: translate('payroll'),
+    DATATABLE_TITLE: translate('payroll_list'),
+    ADD_NEW_ENTITY: translate('add_new_payroll'),
+    ENTITY_NAME: translate('payroll'),
+  };
+
+  const config = { entity, ...Labels, dataTableColumns };
+
+  return (
+    <>
+      {summary.length > 0 && (
+        <Card
+          title={translate('Total') + ' ' + translate('payroll')}
+          extra={<Link to="/expense">{translate('expense')}</Link>}
+          style={{ marginBottom: 20 }}
+        >
+          <Table
+            rowKey="month"
+            pagination={false}
+            dataSource={summary}
+            columns={[
+              {
+                title: translate('Month'),
+                dataIndex: 'month',
+                render: (m) => dayjs(m).format('MMMM YYYY'),
+              },
+              { title: translate('Total'), dataIndex: 'total' },
+            ]}
+          />
+        </Card>
+      )}
+      <PayrollDataTableModule config={config} />
+    </>
+  );
+}

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -24,6 +24,7 @@ const PaymentRead = lazy(() => import('@/pages/Payment/PaymentRead'));
 const PaymentUpdate = lazy(() => import('@/pages/Payment/PaymentUpdate'));
 const DeliveryNote = lazy(() => import('@/pages/DeliveryNote'));
 const Expense = lazy(() => import('@/pages/Expense'));
+const Payroll = lazy(() => import('@/pages/Payroll'));
 const Purchase = lazy(() => import('@/pages/Purchase'));
 const Reports = lazy(() => import('@/pages/Reports'));
 const Analytics = lazy(() => import('@/pages/Analytics'));
@@ -57,6 +58,7 @@ let routes = {
   ],
   expenses: [
     { path: '/expense', element: <Expense /> },
+    { path: '/payroll', element: <Payroll /> },
   ],
   reports: [
     { path: '/reports', element: <Reports /> },


### PR DESCRIPTION
## Summary
- add payroll list page and route with monthly totals and link to expenses
- enhance payroll form to capture employee, amount, date and expense category
- create payroll summary endpoint and expose through controller

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot read config file .eslintrc.js)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab033c65f08333bbfb9e549633cc2a