### PR TITLE
Refactor router and add module routes

### DIFF
--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -1,5 +1,4 @@
 import { lazy } from 'react';
-
 import { Navigate } from 'react-router-dom';
 
 const Logout = lazy(() => import('@/pages/Logout.jsx'));
@@ -11,78 +10,60 @@ const Product = lazy(() => import('@/pages/Product'));
 const ProductCreate = lazy(() => import('@/pages/Product/ProductCreate'));
 const ProductUpdate = lazy(() => import('@/pages/Product/ProductUpdate'));
 const Supplier = lazy(() => import('@/pages/Supplier'));
+
 const Invoice = lazy(() => import('@/pages/Invoice'));
 const InvoiceCreate = lazy(() => import('@/pages/Invoice/InvoiceCreate'));
 const InvoiceRead = lazy(() => import('@/pages/Invoice/InvoiceRead'));
 const InvoiceUpdate = lazy(() => import('@/pages/Invoice/InvoiceUpdate'));
 const InvoiceRecordPayment = lazy(() => import('@/pages/Invoice/InvoiceRecordPayment'));
-const Quote = lazy(() => import('@/pages/Quote/index'));
+
+const Quote = lazy(() => import('@/pages/Quote'));
 const QuoteCreate = lazy(() => import('@/pages/Quote/QuoteCreate'));
 const QuoteRead = lazy(() => import('@/pages/Quote/QuoteRead'));
 const QuoteUpdate = lazy(() => import('@/pages/Quote/QuoteUpdate'));
-const Payment = lazy(() => import('@/pages/Payment/index'));
+
+const Payment = lazy(() => import('@/pages/Payment'));
 const PaymentRead = lazy(() => import('@/pages/Payment/PaymentRead'));
 const PaymentUpdate = lazy(() => import('@/pages/Payment/PaymentUpdate'));
+
+const Purchase = lazy(() => import('@/pages/Purchase'));
+const PurchaseCreate = lazy(() => import('@/pages/Purchase/PurchaseCreate'));
+const PurchaseRead = lazy(() => import('@/pages/Purchase/PurchaseRead'));
+
 const DeliveryNote = lazy(() => import('@/pages/DeliveryNote'));
 const DeliveryNoteCreate = lazy(() => import('@/pages/DeliveryNote/DeliveryNoteCreate'));
 const DeliveryNoteRead = lazy(() => import('@/pages/DeliveryNote/DeliveryNoteRead'));
 const DeliveryNoteUpdate = lazy(() => import('@/pages/DeliveryNote/DeliveryNoteUpdate'));
+
+const StockLedger = lazy(() => import('@/pages/StockLedger'));
+
 const Expense = lazy(() => import('@/pages/Expense'));
-const Payroll = lazy(() => import('@/pages/Payroll'));
 const ExpenseCategory = lazy(() => import('@/pages/ExpenseCategory'));
-const Purchase = lazy(() => import('@/pages/Purchase'));
-const PurchaseCreate = lazy(() => import('@/pages/Purchase/PurchaseCreate'));
-const PurchaseRead = lazy(() => import('@/pages/Purchase/PurchaseRead'));
+const Employee = lazy(() => import('@/pages/Employee'));
+const Payroll = lazy(() => import('@/pages/Payroll'));
+
 const Reports = lazy(() => import('@/pages/Reports'));
 const Analytics = lazy(() => import('@/pages/Analytics'));
-
-const ReportPage = lazy(() => import('@/pages/Report'));
-const AnalyticsPage = lazy(() => import('@/pages/Analytics'));
 
 const Settings = lazy(() => import('@/pages/Settings/Settings'));
 const PaymentMode = lazy(() => import('@/pages/PaymentMode'));
 const Taxes = lazy(() => import('@/pages/Taxes'));
-
 const Profile = lazy(() => import('@/pages/Profile'));
-
 const About = lazy(() => import('@/pages/About'));
 
-let routes = {
+const routes = {
   master: [
     { path: '/customer', element: <Customer /> },
     { path: '/products', element: <Product /> },
+    { path: '/products/create', element: <ProductCreate /> },
+    { path: '/products/update/:id', element: <ProductUpdate /> },
     { path: '/supplier', element: <Supplier /> },
     { path: '/payment/mode', element: <PaymentMode /> },
     { path: '/taxes', element: <Taxes /> },
     { path: '/settings', element: <Settings /> },
     { path: '/settings/edit/:settingsKey', element: <Settings /> },
   ],
-  purchasing: [
-    { path: '/purchase', element: <Purchase /> },
-    { path: '/purchase/create', element: <PurchaseCreate /> },
-    { path: '/purchase/read/:id', element: <PurchaseRead /> },
-  ],
-  delivery: [
-    { path: '/deliverynote', element: <DeliveryNote /> },
-  ],
-  expenses: [
-    { path: '/expense', element: <Expense /> },
-    { path: '/payroll', element: <Payroll /> },
-    { path: '/expensecategory', element: <ExpenseCategory /> },
-  ],
-  reports: [
-    { path: '/reports', element: <Reports /> },
-  ],
-  analytics: [
-    { path: '/analytics', element: <Analytics /> },
-  ],
-  default: [
-    { path: '/login', element: <Navigate to="/" /> },
-    { path: '/logout', element: <Logout /> },
-    { path: '/about', element: <About /> },
-        { path: '/products', element: <Product /> },
-    { path: '/products/create', element: <ProductCreate /> },
-    { path: '/products/update/:id', element: <ProductUpdate /> },
+  sales: [
     { path: '/invoice', element: <Invoice /> },
     { path: '/invoice/create', element: <InvoiceCreate /> },
     { path: '/invoice/read/:id', element: <InvoiceRead /> },
@@ -95,144 +76,36 @@ let routes = {
     { path: '/payment', element: <Payment /> },
     { path: '/payment/read/:id', element: <PaymentRead /> },
     { path: '/payment/update/:id', element: <PaymentUpdate /> },
-    { path: '/expensecategory', element: <ExpenseCategory /> },
+    { path: '/deliverynote', element: <DeliveryNote /> },
+    { path: '/deliverynote/create', element: <DeliveryNoteCreate /> },
+    { path: '/deliverynote/read/:id', element: <DeliveryNoteRead /> },
+    { path: '/deliverynote/update/:id', element: <DeliveryNoteUpdate /> },
+  ],
+  purchasing: [
     { path: '/purchase', element: <Purchase /> },
     { path: '/purchase/create', element: <PurchaseCreate /> },
     { path: '/purchase/read/:id', element: <PurchaseRead /> },
+    { path: '/stockledger', element: <StockLedger /> },
+  ],
+  expenses: [
+    { path: '/expense', element: <Expense /> },
+    { path: '/expensecategory', element: <ExpenseCategory /> },
+    { path: '/employee', element: <Employee /> },
+    { path: '/payroll', element: <Payroll /> },
+  ],
+  reports: [
+    { path: '/reports', element: <Reports /> },
+  ],
+  analytics: [
+    { path: '/analytics', element: <Analytics /> },
+  ],
+  default: [
+    { path: '/', element: <Dashboard /> },
+    { path: '/login', element: <Navigate to="/" /> },
+    { path: '/logout', element: <Logout /> },
+    { path: '/about', element: <About /> },
     { path: '/profile', element: <Profile /> },
     { path: '*', element: <NotFound /> },
-    {
-      path: '/login',
-      element: <Navigate to="/" />,
-    },
-    {
-      path: '/logout',
-      element: <Logout />,
-    },
-    {
-      path: '/about',
-      element: <About />,
-    },
-    {
-      path: '/',
-      element: <Dashboard />,
-    },
-    {
-      path: '/customer',
-      element: <Customer />,
-    },
-    {
-      path: '/products',
-      element: <Product />,
-    },
-    {
-      path: '/products/create',
-      element: <ProductCreate />,
-    },
-    {
-      path: '/products/update/:id',
-      element: <ProductUpdate />,
-    },
-
-    {
-      path: '/invoice',
-      element: <Invoice />,
-    },
-    {
-      path: '/invoice/create',
-      element: <InvoiceCreate />,
-    },
-    {
-      path: '/invoice/read/:id',
-      element: <InvoiceRead />,
-    },
-    {
-      path: '/invoice/update/:id',
-      element: <InvoiceUpdate />,
-    },
-    {
-      path: '/invoice/pay/:id',
-      element: <InvoiceRecordPayment />,
-    },
-    {
-      path: '/quote',
-      element: <Quote />,
-    },
-    {
-      path: '/quote/create',
-      element: <QuoteCreate />,
-    },
-    {
-      path: '/quote/read/:id',
-      element: <QuoteRead />,
-    },
-    {
-      path: '/quote/update/:id',
-      element: <QuoteUpdate />,
-    },
-    {
-      path: '/payment',
-      element: <Payment />,
-    },
-    {
-      path: '/payment/read/:id',
-      element: <PaymentRead />,
-    },
-    {
-      path: '/payment/update/:id',
-      element: <PaymentUpdate />,
-    },
-
-    {
-      path: '/deliverynote',
-      element: <DeliveryNote />,
-    },
-    {
-      path: '/deliverynote/create',
-      element: <DeliveryNoteCreate />,
-    },
-    {
-      path: '/deliverynote/read/:id',
-      element: <DeliveryNoteRead />,
-    },
-    {
-      path: '/deliverynote/update/:id',
-      element: <DeliveryNoteUpdate />,
-    },
-    {
-      path: '/reports',
-      element: <ReportPage />,
-    },
-    {
-      path: '/analytics',
-      element: <AnalyticsPage />,
-    },
-
-    {
-      path: '/settings',
-      element: <Settings />,
-    },
-    {
-      path: '/settings/edit/:settingsKey',
-      element: <Settings />,
-    },
-    {
-      path: '/payment/mode',
-      element: <PaymentMode />,
-    },
-    {
-      path: '/taxes',
-      element: <Taxes />,
-    },
-
-    {
-      path: '/profile',
-      element: <Profile />,
-    },
-    {
-      path: '*',
-      element: <NotFound />,
-    },
   ],
 };
 


### PR DESCRIPTION
## Summary
- clean up duplicate route declarations
- add module routes for product, supplier, purchase, delivery note, stock ledger, expense category, employee, payroll, reports, and analytics with lazy imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot read config file .eslintrc.js)*
- `npm run build` *(fails: Unexpected "AnalyticsModule" in Analytics page)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0817cc0883339086a4a043afccbe