### PR TITLE
feat: improve responsive tables and forms

### DIFF
--- a/frontend/src/components/CreateForm/index.jsx
+++ b/frontend/src/components/CreateForm/index.jsx
@@ -7,8 +7,10 @@ import { selectCreatedItem } from '@/redux/crud/selectors';
 
 import useLanguage from '@/locale/useLanguage';
 
-import { Button, Form } from 'antd';
+import { Button, Form, Grid } from 'antd';
 import Loading from '@/components/Loading';
+
+const { useBreakpoint } = Grid;
 
 export default function CreateForm({ config, formElements, withUpload = false }) {
   let { entity } = config;
@@ -17,6 +19,7 @@ export default function CreateForm({ config, formElements, withUpload = false })
   const { crudContextAction } = useCrudContext();
   const { panel, collapsedBox, readBox } = crudContextAction;
   const [form] = Form.useForm();
+  const screens = useBreakpoint();
   const translate = useLanguage();
   const onSubmit = (fieldsValue) => {
     // Manually trim values before submission
@@ -46,7 +49,13 @@ export default function CreateForm({ config, formElements, withUpload = false })
 
   return (
     <Loading isLoading={isLoading}>
-      <Form form={form} layout="vertical" onFinish={onSubmit}>
+      <Form
+        form={form}
+        layout={screens.md ? 'horizontal' : 'vertical'}
+        labelCol={screens.md ? { span: 8 } : undefined}
+        wrapperCol={screens.md ? { span: 16 } : undefined}
+        onFinish={onSubmit}
+      >
         {formElements}
         <Form.Item>
           <Button type="primary" htmlType="submit">

--- a/frontend/src/components/DataTable/DataTable.jsx
+++ b/frontend/src/components/DataTable/DataTable.jsx
@@ -207,7 +207,7 @@ export default function DataTable({ config, extra = [] }) {
         pagination={pagination}
         loading={listIsLoading}
         onChange={handelDataTableLoad}
-        scroll={{ x: true }}
+        scroll={{ x: 'max-content' }}
       />
     </>
   );

--- a/frontend/src/components/SidePanel/index.jsx
+++ b/frontend/src/components/SidePanel/index.jsx
@@ -60,7 +60,7 @@ export default function SidePanel({ config, topContent, bottomContent, fixHeader
       placement="right"
       onClose={collapsePanel}
       open={!isPanelClose}
-      width={450}
+      width={screens.xs ? '100%' : 450}
     >
       <div
         className="sidePanelContent"

--- a/frontend/src/components/UpdateForm/index.jsx
+++ b/frontend/src/components/UpdateForm/index.jsx
@@ -8,12 +8,13 @@ import { selectUpdatedItem } from '@/redux/crud/selectors';
 
 import useLanguage from '@/locale/useLanguage';
 
-import { Button, Form } from 'antd';
+import { Button, Form, Grid } from 'antd';
 import Loading from '@/components/Loading';
+
+const { useBreakpoint } = Grid;
 
 export default function UpdateForm({ config, formElements, withUpload = false }) {
   let { entity } = config;
-  const translate = useLanguage();
   const dispatch = useDispatch();
   const { current, isLoading, isSuccess } = useSelector(selectUpdatedItem);
 
@@ -29,6 +30,8 @@ export default function UpdateForm({ config, formElements, withUpload = false })
 
   /////
   const [form] = Form.useForm();
+  const screens = useBreakpoint();
+  const translate = useLanguage();
 
   const onSubmit = (fieldsValue) => {
     const id = current._id;
@@ -103,7 +106,13 @@ export default function UpdateForm({ config, formElements, withUpload = false })
   return (
     <div style={show}>
       <Loading isLoading={isLoading}>
-        <Form form={form} layout="vertical" onFinish={onSubmit}>
+        <Form
+          form={form}
+          layout={screens.md ? 'horizontal' : 'vertical'}
+          labelCol={screens.md ? { span: 8 } : undefined}
+          wrapperCol={screens.md ? { span: 16 } : undefined}
+          onFinish={onSubmit}
+        >
           {formElements}
           <Form.Item
             style={{

--- a/frontend/src/modules/DashboardModule/components/RecentTable/index.jsx
+++ b/frontend/src/modules/DashboardModule/components/RecentTable/index.jsx
@@ -100,7 +100,7 @@ export default function RecentTable({ ...props }) {
       dataSource={isSuccess && firstFiveItems()}
       pagination={false}
       loading={isLoading}
-      scroll={{ x: true }}
+      scroll={{ x: 'max-content' }}
     />
   );
 }

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -230,7 +230,7 @@ export default function DataTable({ config, extra = [] }) {
         pagination={pagination}
         loading={listIsLoading}
         onChange={handelDataTableLoad}
-        scroll={{ x: true }}
+        scroll={{ x: 'max-content' }}
       />
     </>
   );

--- a/frontend/src/modules/ReportModule/index.jsx
+++ b/frontend/src/modules/ReportModule/index.jsx
@@ -35,6 +35,7 @@ export default function ReportModule() {
               { title: translate('Bucket'), dataIndex: 'bucket' },
               { title: translate('Amount'), dataIndex: 'amount' },
             ]}
+            scroll={{ x: 'max-content' }}
           />
         </Card>
       )}

--- a/frontend/src/modules/StockLedgerModule/StockLedgerDataTableModule/index.jsx
+++ b/frontend/src/modules/StockLedgerModule/StockLedgerDataTableModule/index.jsx
@@ -95,7 +95,7 @@ export default function StockLedgerDataTableModule() {
             onChange={(value) => setProduct(value)}
           />
         </Space>
-        <Table columns={columns} dataSource={filtered} rowKey="id" />
+        <Table columns={columns} dataSource={filtered} rowKey="id" scroll={{ x: 'max-content' }} />
         {chartData.length > 0 && (
           <Card title="Stock Overview">
             <ResponsiveContainer width="100%" height={300}>

--- a/frontend/src/modules/SupplierModule/SupplierDataTableModule/index.jsx
+++ b/frontend/src/modules/SupplierModule/SupplierDataTableModule/index.jsx
@@ -107,6 +107,7 @@ export default function SupplierDataTableModule() {
         dataSource={filtered}
         columns={columns}
         loading={loading}
+        scroll={{ x: 'max-content' }}
       />
       <Modal
         open={modalOpen}

--- a/frontend/src/pages/Payroll/index.jsx
+++ b/frontend/src/pages/Payroll/index.jsx
@@ -61,6 +61,7 @@ export default function Payroll() {
               },
               { title: translate('Total'), dataIndex: 'total' },
             ]}
+            scroll={{ x: 'max-content' }}
           />
         </Card>
       )}


### PR DESCRIPTION
## Summary
- allow tables to horizontally scroll on narrow screens
- adapt form layouts to screen size with Ant Design useBreakpoint
- expand side drawer to full width on mobile

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot read config file /workspace/ERP-Node/frontend/.eslintrc.js)


------
https://chatgpt.com/codex/tasks/task_e_68ab081c0d508333bcee5cda5fdf24c1