### PR TITLE
Fix repeated fetch loop when record missing

### DIFF
--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -39,16 +39,17 @@ const { Sider } = Layout;
 export default function Navigation() {
   const { screenSize } = useResponsive();
   const {
+    state: { isNavMenuClose },
     appContextAction: { navMenu },
   } = useAppContext();
 
   useEffect(() => {
-    if (!screenSize.md) {
+    if (!screenSize.md && !isNavMenuClose) {
       navMenu.close();
-    } else {
+    } else if (screenSize.md && isNavMenuClose) {
       navMenu.open();
     }
-  }, [screenSize.md, navMenu]);
+  }, [screenSize.md, isNavMenuClose, navMenu]);
 
   return !screenSize.sm ? <MobileSidebar /> : <Sidebar collapsible={true} />;
 }

--- a/frontend/src/context/appContext/index.jsx
+++ b/frontend/src/context/appContext/index.jsx
@@ -17,7 +17,7 @@ function useAppContext() {
     throw new Error('useAppContext must be used within a AppContextProvider');
   }
   const [state, dispatch] = context;
-  const appContextAction = contextActions(dispatch);
+  const appContextAction = useMemo(() => contextActions(dispatch), [dispatch]);
   // const appContextSelector = contextSelectors(state);
   return { state, appContextAction };
 }

--- a/frontend/src/modules/InvoiceModule/RecordPaymentModule/index.jsx
+++ b/frontend/src/modules/InvoiceModule/RecordPaymentModule/index.jsx
@@ -2,7 +2,7 @@ import { ErpLayout } from '@/layout';
 
 import PageLoader from '@/components/PageLoader';
 import { erp } from '@/redux/erp/actions';
-import { selectItemById, selectCurrentItem, selectRecordPaymentItem } from '@/redux/erp/selectors';
+import { selectItemById, selectCurrentItem } from '@/redux/erp/selectors';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
@@ -13,25 +13,25 @@ export default function RecordPaymentModule({ config }) {
   const { id } = useParams();
 
   let item = useSelector(selectItemById(id));
+  const { result: currentResult } = useSelector(selectCurrentItem);
+  item = item || currentResult;
+
+  useEffect(() => {
+    if (!item) {
+      dispatch(erp.read({ entity: config.entity, id }));
+    }
+  }, [dispatch, id]);
 
   useEffect(() => {
     if (item) {
       dispatch(erp.currentItem({ data: item }));
-    } else {
-      dispatch(erp.read({ entity: config.entity, id }));
+      dispatch(erp.currentAction({ actionType: 'recordPayment', data: item }));
     }
-  }, [item, id]);
-
-  const { result: currentResult } = useSelector(selectCurrentItem);
-  item = currentResult;
-
-  useEffect(() => {
-    dispatch(erp.currentAction({ actionType: 'recordPayment', data: item }));
-  }, [item]);
+  }, [dispatch, item]);
 
   return (
     <ErpLayout>
-      {item ? <Payment config={config} currentItem={currentResult} /> : <PageLoader />}
+      {item ? <Payment config={config} currentItem={item} /> : <PageLoader />}
     </ErpLayout>
   );
 }

--- a/frontend/src/modules/PaymentModule/ReadPaymentModule/index.jsx
+++ b/frontend/src/modules/PaymentModule/ReadPaymentModule/index.jsx
@@ -14,17 +14,21 @@ export default function ReadPaymentModule({ config }) {
   const { id } = useParams();
   let item = useSelector(selectItemById(id));
 
+  const { result: currentResult } = useSelector(selectCurrentItem);
+  item = item || currentResult;
+
+  useEffect(() => {
+    if (!item) {
+      dispatch(erp.read({ entity: config.entity, id }));
+    }
+  }, [dispatch, id]);
+
   useEffect(() => {
     if (item) {
       dispatch(erp.currentItem({ data: item }));
-    } else {
-      dispatch(erp.read({ entity: config.entity, id }));
     }
-  }, [item]);
+  }, [dispatch, item]);
 
-  const { result: currentResult } = useSelector(selectCurrentItem);
-
-  item = currentResult;
   return (
     <ErpLayout>
       {item ? <ReadItem config={config} selectedItem={item} /> : <PageLoader />}


### PR DESCRIPTION
## Summary
- avoid infinite redux dispatch when record data is absent in payment and invoice payment modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint` *(fails: Cannot read config file .eslintrc.js: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5892b1c08333ba68587d39fe33d1