### PR TITLE
Handle entities without `removed` column

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createCRUDController/create.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/create.js
@@ -1,8 +1,10 @@
-const { addId } = require('./utils');
+const { addId, hasColumn } = require('./utils');
 
 const create = async (repository, req, res) => {
   try {
-    req.body.removed = false;
+    if (hasColumn(repository, 'removed') && req.body.removed === undefined) {
+      req.body.removed = false;
+    }
     const entity = repository.create({ ...req.body });
     const result = await repository.save(entity);
     return res.status(200).json({

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/filter.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/filter.js
@@ -1,4 +1,4 @@
-const { addId } = require('./utils');
+const { addId, hasColumn } = require('./utils');
 
 const filter = async (repository, req, res) => {
   if (req.query.filter === undefined || req.query.equal === undefined) {
@@ -9,21 +9,21 @@ const filter = async (repository, req, res) => {
     });
   }
   try {
-    const where = { removed: false, [req.query.filter]: req.query.equal };
+    const where = { [req.query.filter]: req.query.equal };
+    if (hasColumn(repository, 'removed')) where.removed = false;
     const result = await repository.find({ where });
     if (!result || result.length === 0) {
-      return res.status(404).json({
-        success: false,
-        result: null,
-        message: 'No document found ',
-      });
-    } else {
       return res.status(200).json({
         success: true,
-        result: addId(result),
-        message: 'Successfully found all documents  ',
+        result: [],
+        message: 'No document found ',
       });
     }
+    return res.status(200).json({
+      success: true,
+      result: addId(result),
+      message: 'Successfully found all documents  ',
+    });
   } catch (error) {
     return res.status(500).json({
       success: false,

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/listAll.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/listAll.js
@@ -1,11 +1,12 @@
-const { addId } = require('./utils');
+const { addId, hasColumn } = require('./utils');
 
 const listAll = async (repository, req, res) => {
   const sort = req.query.sort || 'desc';
   const enabled = req.query.enabled;
 
   try {
-    const where = { removed: false };
+    const where = {};
+    if (hasColumn(repository, 'removed')) where.removed = false;
     if (enabled !== undefined) where.enabled = enabled;
     const result = await repository.find({
       where,
@@ -18,13 +19,12 @@ const listAll = async (repository, req, res) => {
         result: addId(result),
         message: 'Successfully found all documents',
       });
-    } else {
-      return res.status(203).json({
-        success: false,
-        result: [],
-        message: 'Collection is Empty',
-      });
     }
+    return res.status(200).json({
+      success: true,
+      result: [],
+      message: 'Collection is Empty',
+    });
   } catch (error) {
     return res.status(500).json({
       success: false,

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
@@ -1,4 +1,4 @@
-const { addId } = require('./utils');
+const { addId, hasColumn } = require('./utils');
 
 const paginatedList = async (repository, req, res) => {
   const page = parseInt(req.query.page) || 1;
@@ -11,9 +11,12 @@ const paginatedList = async (repository, req, res) => {
   const fieldsArray = req.query.fields ? req.query.fields.split(',') : [];
 
   try {
-    const qb = repository
-      .createQueryBuilder('model')
-      .where('model.removed = :removed', { removed: false });
+    const qb = repository.createQueryBuilder('model');
+    if (hasColumn(repository, 'removed')) {
+      qb.where('model.removed = :removed', { removed: false });
+    } else {
+      qb.where('1 = 1');
+    }
 
     if (filter && equal !== undefined) {
       qb.andWhere(`model.${filter} = :equal`, { equal });
@@ -38,14 +41,13 @@ const paginatedList = async (repository, req, res) => {
         pagination,
         message: 'Successfully found all documents',
       });
-    } else {
-      return res.status(203).json({
-        success: true,
-        result: [],
-        pagination,
-        message: 'Collection is Empty',
-      });
     }
+    return res.status(200).json({
+      success: true,
+      result: [],
+      pagination,
+      message: 'Collection is Empty',
+    });
   } catch (error) {
     return res.status(500).json({
       success: false,

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/read.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/read.js
@@ -1,10 +1,10 @@
-const { addId } = require('./utils');
+const { addId, hasColumn } = require('./utils');
 
 const read = async (repository, req, res) => {
   try {
-    const result = await repository.findOne({
-      where: { id: req.params.id, removed: false },
-    });
+    const where = { id: req.params.id };
+    if (hasColumn(repository, 'removed')) where.removed = false;
+    const result = await repository.findOne({ where });
     if (!result) {
       return res.status(404).json({
         success: false,

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/remove.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/remove.js
@@ -1,4 +1,4 @@
-const { addId } = require('./utils');
+const { addId, hasColumn } = require('./utils');
 
 const remove = async (repository, req, res) => {
   try {
@@ -10,11 +10,19 @@ const remove = async (repository, req, res) => {
         message: 'No document found ',
       });
     }
-    entity.removed = true;
-    const result = await repository.save(entity);
+    if (hasColumn(repository, 'removed')) {
+      entity.removed = true;
+      const result = await repository.save(entity);
+      return res.status(200).json({
+        success: true,
+        result: addId(result),
+        message: 'Successfully Deleted the document ',
+      });
+    }
+    await repository.delete(req.params.id);
     return res.status(200).json({
       success: true,
-      result: addId(result),
+      result: addId(entity),
       message: 'Successfully Deleted the document ',
     });
   } catch (error) {

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/search.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/search.js
@@ -1,8 +1,13 @@
-const { addId } = require('./utils');
+const { addId, hasColumn } = require('./utils');
 
 const search = async (repository, req, res) => {
   const fieldsArray = req.query.fields ? req.query.fields.split(',') : ['name'];
-  const qb = repository.createQueryBuilder('model').where('model.removed = :removed', { removed: false });
+  const qb = repository.createQueryBuilder('model');
+  if (hasColumn(repository, 'removed')) {
+    qb.where('model.removed = :removed', { removed: false });
+  } else {
+    qb.where('1 = 1');
+  }
 
   if (req.query.q && req.query.q.trim() !== '') {
     const where = fieldsArray.map((f) => `model.${f} LIKE :q`).join(' OR ');
@@ -17,16 +22,12 @@ const search = async (repository, req, res) => {
       result: addId(results),
       message: 'Successfully found all documents',
     });
-  } else {
-    return res
-      .status(202)
-      .json({
-        success: false,
-        result: [],
-        message: 'No document found by this request',
-      })
-      .end();
   }
+  return res.status(200).json({
+    success: true,
+    result: [],
+    message: 'No document found by this request',
+  });
 };
 
 module.exports = search;

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/summary.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/summary.js
@@ -1,8 +1,12 @@
+const { hasColumn } = require('./utils');
+
 const summary = async (repository, req, res) => {
   try {
-    const countAllDocs = await repository.count({ where: { removed: false } });
+    const baseWhere = {};
+    if (hasColumn(repository, 'removed')) baseWhere.removed = false;
+    const countAllDocs = await repository.count({ where: baseWhere });
     const countFilter = await repository.count({
-      where: { removed: false, [req.query.filter]: req.query.equal },
+      where: { ...baseWhere, [req.query.filter]: req.query.equal },
     });
 
     if (countAllDocs > 0) {
@@ -11,13 +15,12 @@ const summary = async (repository, req, res) => {
         result: { countFilter, countAllDocs },
         message: 'Successfully count all documents',
       });
-    } else {
-      return res.status(203).json({
-        success: false,
-        result: [],
-        message: 'Collection is Empty',
-      });
     }
+    return res.status(200).json({
+      success: true,
+      result: { countFilter, countAllDocs },
+      message: 'Collection is Empty',
+    });
   } catch (error) {
     return res.status(500).json({
       success: false,

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/update.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/update.js
@@ -1,11 +1,13 @@
-const { addId } = require('./utils');
+const { addId, hasColumn } = require('./utils');
 
 const update = async (repository, req, res) => {
   try {
-    req.body.removed = false;
-    let entity = await repository.findOne({
-      where: { id: req.params.id, removed: false },
-    });
+    if (hasColumn(repository, 'removed') && req.body.removed === undefined) {
+      req.body.removed = false;
+    }
+    const where = { id: req.params.id };
+    if (hasColumn(repository, 'removed')) where.removed = false;
+    let entity = await repository.findOne({ where });
     if (!entity) {
       return res.status(404).json({
         success: false,

--- a/backend/src/controllers/middlewaresControllers/createCRUDController/utils.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/utils.js
@@ -20,5 +20,20 @@ function addId(entity) {
   return entity;
 }
 
-module.exports = { addId };
+/**
+ * Checks if the provided TypeORM repository contains a specific column.
+ *
+ * Some legacy entities in this project do not implement the `removed`
+ * column used for soft deletes. Generic CRUD helpers need to know if the
+ * column exists before referencing it in queries.
+ *
+ * @param {import('typeorm').Repository} repository - TypeORM repository instance
+ * @param {string} column - Column name to look for
+ * @returns {boolean} True when the column exists on the entity
+ */
+function hasColumn(repository, column) {
+  return repository.metadata.columns.some((c) => c.propertyName === column);
+}
+
+module.exports = { addId, hasColumn };
 


### PR DESCRIPTION
## Summary
- avoid referencing non-existent `removed` fields in generic CRUD helpers
- normalize empty-list responses to 200 OK

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acbb978f488333a072ee8fb34ac1da