### PR TITLE
Align supplier form with other modules

### DIFF
--- a/frontend/src/modules/SupplierModule/SupplierDataTableModule/index.jsx
+++ b/frontend/src/modules/SupplierModule/SupplierDataTableModule/index.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Table, Button, Modal, Input, Space } from 'antd';
+import { Table, Button, Drawer, Input, Space } from 'antd';
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { ErpLayout } from '@/layout';
 import SupplierForm from '../SupplierForm';
@@ -14,7 +14,7 @@ export default function SupplierDataTableModule() {
   const [suppliers, setSuppliers] = useState([]);
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
-  const [modalOpen, setModalOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const [editing, setEditing] = useState(null);
 
   const load = async () => {
@@ -36,7 +36,7 @@ export default function SupplierDataTableModule() {
     } else {
       await createSupplier(values);
     }
-    setModalOpen(false);
+    setDrawerOpen(false);
     setEditing(null);
     load();
   };
@@ -69,7 +69,7 @@ export default function SupplierDataTableModule() {
             icon={<EditOutlined />}
             onClick={() => {
               setEditing(record);
-              setModalOpen(true);
+              setDrawerOpen(true);
             }}
           />
           <Button
@@ -96,7 +96,7 @@ export default function SupplierDataTableModule() {
           icon={<PlusOutlined />}
           onClick={() => {
             setEditing(null);
-            setModalOpen(true);
+            setDrawerOpen(true);
           }}
         >
           Add Supplier
@@ -109,17 +109,18 @@ export default function SupplierDataTableModule() {
         loading={loading}
         scroll={{ x: 'max-content' }}
       />
-      <Modal
-        open={modalOpen}
-        footer={null}
+      <Drawer
+        title={editing ? 'Edit Supplier' : 'Add Supplier'}
+        width={480}
+        open={drawerOpen}
         destroyOnClose
-        onCancel={() => {
-          setModalOpen(false);
+        onClose={() => {
+          setDrawerOpen(false);
           setEditing(null);
         }}
       >
         <SupplierForm onSubmit={handleSubmit} defaultValues={editing || {}} />
-      </Modal>
+      </Drawer>
     </ErpLayout>
   );
 }

--- a/frontend/src/modules/SupplierModule/SupplierForm.jsx
+++ b/frontend/src/modules/SupplierModule/SupplierForm.jsx
@@ -1,60 +1,56 @@
-import React, { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
-import { Input, Button } from 'antd';
+import { useEffect } from 'react';
+import { Form, Input, Button } from 'antd';
 
 const { TextArea } = Input;
 
-const schema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  email: z.string().email('Invalid email').optional(),
-  phone: z.string().min(1, 'Phone is required'),
-  address: z.string().min(1, 'Address is required'),
-});
-
-const SupplierForm = ({ onSubmit, defaultValues = { name: '', email: '', phone: '', address: '' } }) => {
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = useForm({
-    resolver: zodResolver(schema),
-    defaultValues,
-  });
+export default function SupplierForm({ onSubmit, defaultValues = { name: '', email: '', phone: '', address: '' } }) {
+  const [form] = Form.useForm();
 
   useEffect(() => {
-    reset(defaultValues);
-  }, [defaultValues, reset]);
+    form.setFieldsValue(defaultValues);
+  }, [defaultValues, form]);
 
-  const submit = (data) => {
-    if (onSubmit) onSubmit(data);
+  const submit = (values) => {
+    if (onSubmit) {
+      onSubmit(values);
+    }
   };
 
   return (
-    <form onSubmit={handleSubmit(submit)}>
-      <div>
-        <Input placeholder="Name" {...register('name')} />
-        {errors.name && <p>{errors.name.message}</p>}
-      </div>
-      <div>
-        <Input placeholder="Email" {...register('email')} />
-        {errors.email && <p>{errors.email.message}</p>}
-      </div>
-      <div>
-        <Input placeholder="Phone" {...register('phone')} />
-        {errors.phone && <p>{errors.phone.message}</p>}
-      </div>
-      <div>
-        <TextArea rows={3} placeholder="Address" {...register('address')} />
-        {errors.address && <p>{errors.address.message}</p>}
-      </div>
-      <Button type="primary" htmlType="submit">
-        Save
-      </Button>
-    </form>
+    <Form form={form} layout="vertical" onFinish={submit}>
+      <Form.Item
+        label="Name"
+        name="name"
+        rules={[{ required: true, message: 'Name is required' }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Email"
+        name="email"
+        rules={[{ type: 'email', message: 'Invalid email' }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Phone"
+        name="phone"
+        rules={[{ required: true, message: 'Phone is required' }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Address"
+        name="address"
+        rules={[{ required: true, message: 'Address is required' }]}
+      >
+        <TextArea rows={3} />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Save
+        </Button>
+      </Form.Item>
+    </Form>
   );
-};
-
-export default SupplierForm;
+}


### PR DESCRIPTION
## Summary
- Replace supplier modal with a side drawer
- Use Ant Design form components for supplier CRUD

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: module is not defined in .eslintrc.js)


------
https://chatgpt.com/codex/tasks/task_e_68acbeb22e348333b913a32572217cfa