### PR TITLE
refactor: improve purchase and product create forms

### DIFF
--- a/frontend/src/modules/ProductModule/CreateProductModule/index.jsx
+++ b/frontend/src/modules/ProductModule/CreateProductModule/index.jsx
@@ -1,11 +1,53 @@
 import { ErpLayout } from '@/layout';
-import CreateItem from '@/modules/ErpPanelModule/CreateItem';
+import { PageHeader } from '@ant-design/pro-layout';
+import { Tag, Button, Form, Divider } from 'antd';
+import { ArrowLeftOutlined, CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
 import ProductForm from '../ProductForm';
+import useLanguage from '@/locale/useLanguage';
 
 export default function CreateProductModule({ config }) {
+  const translate = useLanguage();
+  const navigate = useNavigate();
+  const [form] = Form.useForm();
+  const entity = config?.entity || 'products';
+
+  const onFinish = async (values) => {
+    try {
+      await fetch(`/api/${entity}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      navigate(`/${entity}`);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <ErpLayout>
-      <CreateItem config={config} CreateForm={ProductForm} />
+      <PageHeader
+        onBack={() => navigate(`/${entity}`)}
+        backIcon={<ArrowLeftOutlined />}
+        title={translate('New')}
+        ghost={false}
+        tags={<Tag>{translate('Draft')}</Tag>}
+        extra={[
+          <Button key="cancel" onClick={() => navigate(`/${entity}`)} icon={<CloseCircleOutlined />}>
+            {translate('Cancel')}
+          </Button>,
+          <Button key="save" type="primary" icon={<PlusOutlined />} onClick={() => form.submit()}>
+            {translate('Save')}
+          </Button>,
+        ]}
+        style={{ padding: '20px 0px' }}
+      />
+      <Divider dashed />
+      <Form form={form} layout="vertical" onFinish={onFinish}>
+        <ProductForm />
+      </Form>
     </ErpLayout>
   );
 }
+

--- a/frontend/src/modules/ProductModule/ProductForm.jsx
+++ b/frontend/src/modules/ProductModule/ProductForm.jsx
@@ -1,78 +1,60 @@
-import React from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
-import { Input, Button } from 'antd';
+import { Form, Input, InputNumber } from 'antd';
 
 const { TextArea } = Input;
 
-const schema = z.object({
-  sku: z.string().min(1, 'SKU is required'),
-  name: z.string().min(1, 'Name is required'),
-  price: z.number().nonnegative(),
-  stock: z.number().int().nonnegative(),
-  minStock: z.number().int().nonnegative(),
-  averageCost: z.number().nonnegative(),
-  description: z.string().optional(),
-});
-
-const ProductForm = ({ onSubmit }) => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm({
-    resolver: zodResolver(schema),
-    defaultValues: {
-      sku: '',
-      name: '',
-      price: 0,
-      stock: 0,
-      minStock: 0,
-      averageCost: 0,
-      description: '',
-    },
-  });
-
-  const submit = (data) => {
-    if (onSubmit) onSubmit(data);
-  };
-
+export default function ProductForm() {
   return (
-    <form onSubmit={handleSubmit(submit)}>
-      <div>
-        <Input placeholder="SKU" {...register('sku')} />
-        {errors.sku && <p>{errors.sku.message}</p>}
-      </div>
-      <div>
-        <Input placeholder="Name" {...register('name')} />
-        {errors.name && <p>{errors.name.message}</p>}
-      </div>
-      <div>
-        <Input type="number" placeholder="Price" {...register('price', { valueAsNumber: true })} />
-        {errors.price && <p>{errors.price.message}</p>}
-      </div>
-      <div>
-        <Input type="number" placeholder="Stock" {...register('stock', { valueAsNumber: true })} />
-        {errors.stock && <p>{errors.stock.message}</p>}
-      </div>
-      <div>
-        <Input type="number" placeholder="Min Stock" {...register('minStock', { valueAsNumber: true })} />
-        {errors.minStock && <p>{errors.minStock.message}</p>}
-      </div>
-      <div>
-        <Input type="number" placeholder="Average Cost" {...register('averageCost', { valueAsNumber: true })} />
-        {errors.averageCost && <p>{errors.averageCost.message}</p>}
-      </div>
-      <div>
-        <TextArea rows={4} placeholder="Description" {...register('description')} />
-        {errors.description && <p>{errors.description.message}</p>}
-      </div>
-      <Button type="primary" htmlType="submit">
-        Save
-      </Button>
-    </form>
+    <>
+      <Form.Item
+        label="SKU"
+        name="sku"
+        rules={[{ required: true, message: 'SKU is required' }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Name"
+        name="name"
+        rules={[{ required: true, message: 'Name is required' }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Price"
+        name="price"
+        initialValue={0}
+        rules={[{ required: true, message: 'Price is required' }]}
+      >
+        <InputNumber style={{ width: '100%' }} min={0} />
+      </Form.Item>
+      <Form.Item
+        label="Stock"
+        name="stock"
+        initialValue={0}
+        rules={[{ required: true, message: 'Stock is required' }]}
+      >
+        <InputNumber style={{ width: '100%' }} min={0} />
+      </Form.Item>
+      <Form.Item
+        label="Min Stock"
+        name="minStock"
+        initialValue={0}
+        rules={[{ required: true, message: 'Min stock is required' }]}
+      >
+        <InputNumber style={{ width: '100%' }} min={0} />
+      </Form.Item>
+      <Form.Item
+        label="Average Cost"
+        name="averageCost"
+        initialValue={0}
+        rules={[{ required: true, message: 'Average cost is required' }]}
+      >
+        <InputNumber style={{ width: '100%' }} min={0} />
+      </Form.Item>
+      <Form.Item label="Description" name="description">
+        <TextArea rows={4} />
+      </Form.Item>
+    </>
   );
-};
+}
 
-export default ProductForm;

--- a/frontend/src/modules/PurchaseModule/CreatePurchaseModule/index.jsx
+++ b/frontend/src/modules/PurchaseModule/CreatePurchaseModule/index.jsx
@@ -1,19 +1,84 @@
+import { ErpLayout } from '@/layout';
+import { PageHeader } from '@ant-design/pro-layout';
+import { Tag, Button, Form, Divider, InputNumber } from 'antd';
+import { ArrowLeftOutlined, CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
 import PurchaseForm from '../PurchaseForm';
+import useLanguage from '@/locale/useLanguage';
+import calculate from '@/utils/calculate';
+import { useState } from 'react';
 
-const CreatePurchaseModule = () => {
-  const handleSubmit = async (data) => {
+export default function CreatePurchaseModule({ config }) {
+  const translate = useLanguage();
+  const navigate = useNavigate();
+  const [form] = Form.useForm();
+  const [subTotal, setSubTotal] = useState(0);
+  const entity = config?.entity || 'purchase';
+
+  const onFinish = async (values) => {
+    const payload = {
+      supplier: values.supplier,
+      date: values.date,
+      notes: values.notes,
+      items: values.items?.map((i) => ({ product: i.product, quantity: i.quantity, cost: i.cost })),
+    };
     try {
       await fetch('/api/purchases', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
+        body: JSON.stringify(payload),
       });
+      navigate(`/${entity}`);
     } catch (err) {
       console.error(err);
     }
   };
 
-  return <PurchaseForm onSubmit={handleSubmit} />;
-};
+  const handleValuesChange = (_, values) => {
+    const items = values.items || [];
+    let total = 0;
+    items.forEach((item, idx) => {
+      if (item && item.quantity != null && item.cost != null) {
+        const line = calculate.multiply(item.quantity, item.cost);
+        total = calculate.add(total, line);
+        form.setFields([{ name: ['items', idx, 'total'], value: line }]);
+      }
+    });
+    setSubTotal(total);
+  };
 
-export default CreatePurchaseModule;
+  return (
+    <ErpLayout>
+      <PageHeader
+        onBack={() => navigate(`/${entity}`)}
+        backIcon={<ArrowLeftOutlined />}
+        title={translate('New')}
+        ghost={false}
+        tags={<Tag>{translate('Draft')}</Tag>}
+        extra={[
+          <Button key="cancel" onClick={() => navigate(`/${entity}`)} icon={<CloseCircleOutlined />}>
+            {translate('Cancel')}
+          </Button>,
+          <Button key="save" type="primary" icon={<PlusOutlined />} onClick={() => form.submit()}>
+            {translate('Save')}
+          </Button>,
+        ]}
+        style={{ padding: '20px 0px' }}
+      />
+      <Divider dashed />
+      <Form form={form} layout="vertical" onFinish={onFinish} onValuesChange={handleValuesChange}>
+        <PurchaseForm />
+        <Divider dashed />
+        <div style={{ position: 'relative', width: '100%', float: 'right' }}>
+          <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>
+            <div style={{ paddingRight: '12px' }}>{translate('Sub Total')} :</div>
+            <Form.Item>
+              <InputNumber readOnly value={subTotal} style={{ width: '150px' }} />
+            </Form.Item>
+          </div>
+        </div>
+      </Form>
+    </ErpLayout>
+  );
+}
+

--- a/frontend/src/modules/PurchaseModule/PurchaseForm.jsx
+++ b/frontend/src/modules/PurchaseModule/PurchaseForm.jsx
@@ -1,89 +1,100 @@
-import React, { useState } from 'react';
+import { Row, Col, Form, Input, InputNumber, Button, Divider, DatePicker } from 'antd';
+import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import SelectAsync from '@/components/SelectAsync';
 
-const emptyItem = { product: '', quantity: 0, cost: 0 };
-
-const PurchaseForm = ({ onSubmit }) => {
-  const [form, setForm] = useState({
-    supplier: '',
-    date: '',
-    note: '',
-    items: [emptyItem],
-  });
-
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setForm((f) => ({ ...f, [name]: value }));
-  };
-
-  const handleItemChange = (index, field, value) => {
-    setForm((f) => {
-      const items = f.items.map((item, idx) =>
-        idx === index ? { ...item, [field]: value } : item
-      );
-      return { ...f, items };
-    });
-  };
-
-  const addItem = () => {
-    setForm((f) => ({ ...f, items: [...f.items, { ...emptyItem }] }));
-  };
-
-  const removeItem = (index) => {
-    setForm((f) => ({ ...f, items: f.items.filter((_, idx) => idx !== index) }));
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    onSubmit(form);
-  };
-
+export default function PurchaseForm() {
   return (
-    <form onSubmit={handleSubmit}>
-      <div>
-        <label>Supplier ID</label>
-        <input name="supplier" value={form.supplier} onChange={handleChange} />
-      </div>
-      <div>
-        <label>Date</label>
-        <input type="date" name="date" value={form.date} onChange={handleChange} />
-      </div>
-      <div>
-        <label>Notes</label>
-        <textarea name="note" value={form.note} onChange={handleChange} />
-      </div>
-      <div>
-        <h4>Items</h4>
-        {form.items.map((item, index) => (
-          <div key={index} style={{ marginBottom: '10px' }}>
-            <input
-              placeholder="Product ID"
-              value={item.product}
-              onChange={(e) => handleItemChange(index, 'product', e.target.value)}
-            />
-            <input
-              type="number"
-              placeholder="Qty"
-              value={item.quantity}
-              onChange={(e) => handleItemChange(index, 'quantity', e.target.value)}
-            />
-            <input
-              type="number"
-              placeholder="Cost"
-              value={item.cost}
-              onChange={(e) => handleItemChange(index, 'cost', e.target.value)}
-            />
-            <button type="button" onClick={() => removeItem(index)}>
-              Remove
-            </button>
-          </div>
-        ))}
-        <button type="button" onClick={addItem}>
-          Add Item
-        </button>
-      </div>
-      <button type="submit">Save Purchase</button>
-    </form>
+    <>
+      <Row gutter={[12, 0]}>
+        <Col span={8}>
+          <Form.Item
+            label="Supplier"
+            name="supplier"
+            rules={[{ required: true, message: 'Supplier is required' }]}
+          >
+            <SelectAsync entity={'suppliers'} outputValue={'id'} displayLabels={['name']} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item
+            label="Date"
+            name="date"
+            initialValue={dayjs()}
+            rules={[{ required: true, type: 'object', message: 'Date is required' }]}
+          >
+            <DatePicker style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item label="Notes" name="notes">
+            <Input />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Divider dashed />
+      <Row gutter={[12, 0]}>
+        <Col span={8}>
+          <p>Product</p>
+        </Col>
+        <Col span={4}>
+          <p>Quantity</p>
+        </Col>
+        <Col span={4}>
+          <p>Cost</p>
+        </Col>
+        <Col span={4}>
+          <p>Total</p>
+        </Col>
+      </Row>
+      <Form.List name="items">
+        {(fields, { add, remove }) => (
+          <>
+            {fields.map((field) => (
+              <Row key={field.key} gutter={[12, 12]} style={{ position: 'relative' }}>
+                <Col span={8}>
+                  <Form.Item
+                    name={[field.name, 'product']}
+                    rules={[{ required: true, message: 'Product is required' }]}
+                  >
+                    <SelectAsync entity={'products'} outputValue={'id'} displayLabels={['name']} />
+                  </Form.Item>
+                </Col>
+                <Col span={4}>
+                  <Form.Item
+                    name={[field.name, 'quantity']}
+                    rules={[{ required: true, message: 'Quantity is required' }]}
+                  >
+                    <InputNumber min={0} style={{ width: '100%' }} />
+                  </Form.Item>
+                </Col>
+                <Col span={4}>
+                  <Form.Item
+                    name={[field.name, 'cost']}
+                    rules={[{ required: true, message: 'Cost is required' }]}
+                  >
+                    <InputNumber min={0} style={{ width: '100%' }} />
+                  </Form.Item>
+                </Col>
+                <Col span={4}>
+                  <Form.Item name={[field.name, 'total']}>
+                    <InputNumber readOnly min={0} style={{ width: '100%' }} />
+                  </Form.Item>
+                </Col>
+                <div style={{ position: 'absolute', right: '-20px', top: '5px' }}>
+                  <DeleteOutlined onClick={() => remove(field.name)} />
+                </div>
+              </Row>
+            ))}
+            <Form.Item>
+              <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
+                Add Item
+              </Button>
+            </Form.Item>
+          </>
+        )}
+      </Form.List>
+    </>
   );
-};
+}
 
-export default PurchaseForm;

--- a/frontend/src/pages/Purchase/PurchaseCreate.jsx
+++ b/frontend/src/pages/Purchase/PurchaseCreate.jsx
@@ -1,5 +1,16 @@
+import useLanguage from '@/locale/useLanguage';
 import { CreatePurchaseModule } from '@/modules/PurchaseModule';
 
 export default function PurchaseCreate() {
-  return <CreatePurchaseModule />;
+  const translate = useLanguage();
+  const entity = 'purchase';
+  const Labels = {
+    PANEL_TITLE: translate('purchase'),
+    DATATABLE_TITLE: translate('purchase_list'),
+    ADD_NEW_ENTITY: translate('add_new_purchase'),
+    ENTITY_NAME: translate('purchase'),
+  };
+  const config = { entity, ...Labels };
+  return <CreatePurchaseModule config={config} />;
 }
+


### PR DESCRIPTION
## Summary
- redesign product creation form with Ant Design layout
- build purchase creation form with structured items and subtotal
- integrate styled page headers for product and purchase create flows

## Testing
- `npm run lint` (fails: module is not defined in .eslintrc.js)


------
https://chatgpt.com/codex/tasks/task_e_68b20720d8f48333b548c94d581eb1de