### PR TITLE
Use uppercase payment statuses and adjust summary

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/summary.js
+++ b/backend/src/controllers/appControllers/invoiceController/summary.js
@@ -27,15 +27,15 @@ const summary = async (req, res) => {
   let startDate = currentDate.clone().startOf(defaultType);
   let endDate = currentDate.clone().endOf(defaultType);
 
-  const statuses = ['draft', 'pending', 'overdue', 'paid', 'unpaid', 'partially'];
+  const statuses = ['draft', 'pending', 'OVERDUE', 'PAID', 'UNPAID', 'PARTIAL'];
   const invoices = await Model.find({ where: { removed: false } });
   const totalInvoices = { total: invoices.reduce((acc, i) => acc + i.total, 0), count: invoices.length };
 
   const result = statuses.map((status) => {
     let count = 0;
-    if (status === 'overdue') {
+    if (status === 'OVERDUE') {
       count = invoices.filter((i) => i.expiredDate && i.expiredDate < new Date()).length;
-    } else if (['paid', 'unpaid', 'partially'].includes(status)) {
+    } else if (['PAID', 'UNPAID', 'PARTIAL'].includes(status)) {
       count = invoices.filter((i) => i.paymentStatus === status).length;
     } else {
       count = invoices.filter((i) => i.status === status).length;
@@ -45,7 +45,7 @@ const summary = async (req, res) => {
   });
 
   const unpaid = invoices
-    .filter((i) => ['unpaid', 'partially'].includes(i.paymentStatus))
+    .filter((i) => ['UNPAID', 'PARTIAL'].includes(i.paymentStatus))
     .reduce((acc, i) => acc + (i.total - i.credit), 0);
 
   const finalResult = {

--- a/backend/src/controllers/appControllers/invoiceController/update.js
+++ b/backend/src/controllers/appControllers/invoiceController/update.js
@@ -61,7 +61,7 @@ const update = async (req, res) => {
   // Find document by id and updates with the required fields
 
   let paymentStatus =
-    calculate.sub(total, discount) === credit ? 'paid' : credit > 0 ? 'partially' : 'unpaid';
+    calculate.sub(total, discount) === credit ? 'PAID' : credit > 0 ? 'PARTIAL' : 'UNPAID';
   body['paymentStatus'] = paymentStatus;
 
   Model.merge(previousInvoice, body);

--- a/backend/src/controllers/appControllers/paymentController/create.js
+++ b/backend/src/controllers/appControllers/paymentController/create.js
@@ -48,10 +48,10 @@ const create = async (req, res) => {
 
   let paymentStatus =
     calculate.sub(total, discount) === calculate.add(credit, amount)
-      ? 'paid'
+      ? 'PAID'
       : calculate.add(credit, amount) > 0
-      ? 'partially'
-      : 'unpaid';
+      ? 'PARTIAL'
+      : 'UNPAID';
 
   currentInvoice.payment = [...(currentInvoice.payment || []), paymentId];
   currentInvoice.credit = credit + amount;

--- a/backend/src/controllers/appControllers/paymentController/remove.js
+++ b/backend/src/controllers/appControllers/paymentController/remove.js
@@ -32,10 +32,10 @@ const remove = async (req, res) => {
 
   let paymentStatus =
     total - discount === previousCredit - previousAmount
-      ? 'paid'
+      ? 'PAID'
       : previousCredit - previousAmount > 0
-      ? 'partially'
-      : 'unpaid';
+      ? 'PARTIAL'
+      : 'UNPAID';
 
   invoice.payment = (invoice.payment || []).filter((p) => p !== paymentId);
   invoice.credit = previousCredit - previousAmount;

--- a/backend/src/controllers/appControllers/paymentController/update.js
+++ b/backend/src/controllers/appControllers/paymentController/update.js
@@ -36,10 +36,10 @@ const update = async (req, res) => {
 
   let paymentStatus =
     calculate.sub(total, discount) === calculate.add(previousCredit, changedAmount)
-      ? 'paid'
+      ? 'PAID'
       : calculate.add(previousCredit, changedAmount) > 0
-      ? 'partially'
-      : 'unpaid';
+      ? 'PARTIAL'
+      : 'UNPAID';
 
   const updatedDate = new Date();
   const updates = {

--- a/backend/src/entities/Invoice.js
+++ b/backend/src/entities/Invoice.js
@@ -24,7 +24,11 @@ module.exports = new EntitySchema({
     credit: { type: 'float', default: 0 },
     discount: { type: 'float', default: 0 },
     payment: { type: 'simple-json', nullable: true },
-    paymentStatus: { type: 'varchar', default: 'UNPAID' },
+    paymentStatus: {
+      type: 'enum',
+      enum: ['PAID', 'UNPAID', 'PARTIAL', 'OVERDUE'],
+      default: 'UNPAID',
+    },
     isOverdue: { type: 'boolean', default: false },
     approved: { type: 'boolean', default: false },
     notes: { type: 'text', nullable: true },

--- a/backend/src/services/quoteService.js
+++ b/backend/src/services/quoteService.js
@@ -34,7 +34,7 @@ const convertQuoteToInvoice = async (id, adminId) => {
     discount: quote.discount,
     notes: quote.notes,
     createdBy: adminId,
-    paymentStatus: 'unpaid',
+    paymentStatus: 'UNPAID',
     credit: 0,
   };
 


### PR DESCRIPTION
## Summary
- standardize invoice and payment controllers to use uppercase payment status strings
- extend Invoice entity with enum [`PAID`, `UNPAID`, `PARTIAL`, `OVERDUE`]
- align summary calculations and quote conversion with new status constants

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68b5f1890b208333b4e5dbb6eea58f6b