### PR TITLE
Use uppercase invoice statuses

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/summary.js
+++ b/backend/src/controllers/appControllers/invoiceController/summary.js
@@ -27,25 +27,23 @@ const summary = async (req, res) => {
   let startDate = currentDate.clone().startOf(defaultType);
   let endDate = currentDate.clone().endOf(defaultType);
 
-  const statuses = ['draft', 'pending', 'OVERDUE', 'PAID', 'UNPAID', 'PARTIAL'];
+  const statuses = ['DRAFT', 'PENDING', 'OVERDUE', 'PAID', 'UNPAID', 'PARTIAL'];
   const invoices = await Model.find({ where: { removed: false } });
   const totalInvoices = { total: invoices.reduce((acc, i) => acc + i.total, 0), count: invoices.length };
 
   const result = statuses.map((status) => {
     let count = 0;
-    if (status === 'OVERDUE') {
-      count = invoices.filter((i) => i.expiredDate && i.expiredDate < new Date()).length;
-    } else if (['PAID', 'UNPAID', 'PARTIAL'].includes(status)) {
+    if (['PAID', 'UNPAID', 'PARTIAL', 'OVERDUE'].includes(status)) {
       count = invoices.filter((i) => i.paymentStatus === status).length;
     } else {
-      count = invoices.filter((i) => i.status === status).length;
+      count = invoices.filter((i) => (i.status || '').toUpperCase() === status).length;
     }
     const percentage = totalInvoices.count ? Math.round((count / totalInvoices.count) * 100) : 0;
     return { status, count, percentage };
   });
 
   const unpaid = invoices
-    .filter((i) => ['UNPAID', 'PARTIAL'].includes(i.paymentStatus))
+    .filter((i) => ['UNPAID', 'PARTIAL', 'OVERDUE'].includes(i.paymentStatus))
     .reduce((acc, i) => acc + (i.total - i.credit), 0);
 
   const finalResult = {


### PR DESCRIPTION
## Summary
- standardize invoice summary to use uppercase status labels
- count overdue invoices via payment status and include them in unpaid totals

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f5f55bc8833392a5eed6a4e34839