### PR TITLE
Add login rate limiting and remove debug log

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/login.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/login.js
@@ -29,7 +29,6 @@ const login = async (req, res, { userModel }) => {
 
   const user = await UserRepository.findOne({ where: { email: email, removed: false } });
 
-  console.log(user);
   if (!user)
     return res.status(404).json({
       success: false,

--- a/backend/src/routes/coreRoutes/coreAuth.js
+++ b/backend/src/routes/coreRoutes/coreAuth.js
@@ -1,11 +1,18 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 
 const router = express.Router();
 
 const { catchErrors } = require('@/handlers/errorHandlers');
 const adminAuth = require('@/controllers/coreControllers/adminAuth');
 
-router.route('/login').post(catchErrors(adminAuth.login));
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: 'Too many login attempts. Please try again later.',
+});
+
+router.route('/login').post(loginLimiter, catchErrors(adminAuth.login));
 
 router.route('/forgetpassword').post(catchErrors(adminAuth.forgetPassword));
 router.route('/resetpassword').post(catchErrors(adminAuth.resetPassword));


### PR DESCRIPTION
## Summary
- remove console log from login middleware
- protect login route with express-rate-limit to deter brute force attacks

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f5f71e6c8333a3a1f6554b9c2ac1