### PR TITLE
Add SMTP email sending for PDFs

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -11,3 +11,11 @@ DB_PASSWORD = "Herjuna_3008"
 DB_USER = "supersay_admin"
 DB_PORT = "3306"
 DB_HOST = "united.jagoanhosting.com"
+
+# SMTP configuration
+SMTP_HOST = "smtp.example.com"
+SMTP_PORT = "587"
+SMTP_SECURE = "false"
+SMTP_USER = "user@example.com"
+SMTP_PASS = "password"
+SMTP_FROM = "no-reply@example.com"

--- a/backend/src/controllers/appControllers/invoiceController/sendMail.js
+++ b/backend/src/controllers/appControllers/invoiceController/sendMail.js
@@ -1,11 +1,102 @@
+const nodemailer = require('nodemailer');
+const path = require('path');
 const fs = require('fs');
 
+const { AppDataSource } = require('@/typeorm-data-source');
+const custom = require('@/controllers/pdfController');
+const { SendInvoice } = require('@/emailTemplate/SendEmailTemplate');
+
 const mail = async (req, res) => {
-  return res.status(200).json({
-    success: true,
-    result: null,
-    message: 'Please Upgrade to Premium  Version to have full features',
-  });
+  try {
+    const id = Number(req.params.id || req.body.id);
+    const { email, subject = 'Invoice from Idurar', name = '' } = req.body || {};
+
+    if (!id) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        message: 'Invoice id is required',
+      });
+    }
+
+    const invoiceRepo = AppDataSource.getRepository('Invoice');
+    const invoice = await invoiceRepo.findOne({ where: { id } });
+
+    if (!invoice) {
+      return res.status(404).json({
+        success: false,
+        result: null,
+        message: 'Invoice not found',
+      });
+    }
+
+    let to = email;
+    let clientName = name;
+
+    if (!to && invoice.client) {
+      const clientRepo = AppDataSource.getRepository('Client');
+      const client = await clientRepo.findOne({ where: { id: invoice.client } });
+      to = client ? client.email : to;
+      clientName = client ? client.name : clientName;
+    }
+
+    if (!to) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        message: 'Recipient email is required',
+      });
+    }
+
+    const fileId = `invoice-${invoice.id}.pdf`;
+    const folderPath = path.join('src', 'public', 'download', 'invoice');
+    const targetLocation = path.join(folderPath, fileId);
+
+    fs.mkdirSync(folderPath, { recursive: true });
+
+    await custom.generatePdf(
+      'invoice',
+      { filename: 'invoice', format: 'A4', targetLocation },
+      invoice
+    );
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const html = SendInvoice({ title: subject, name: clientName, time: new Date() });
+
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to,
+      subject,
+      html,
+      attachments: [
+        {
+          filename: fileId,
+          path: targetLocation,
+        },
+      ],
+    });
+
+    return res.status(200).json({
+      success: true,
+      result: null,
+      message: 'Email sent successfully',
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      result: null,
+      message: error.message,
+    });
+  }
 };
 
 module.exports = mail;

--- a/backend/src/controllers/appControllers/paymentController/sendMail.js
+++ b/backend/src/controllers/appControllers/paymentController/sendMail.js
@@ -1,9 +1,107 @@
+const nodemailer = require('nodemailer');
+const path = require('path');
+const fs = require('fs');
+
+const { AppDataSource } = require('@/typeorm-data-source');
+const custom = require('@/controllers/pdfController');
+const { SendPaymentReceipt } = require('@/emailTemplate/SendEmailTemplate');
+
 const mail = async (req, res) => {
-  return res.status(200).json({
-    success: true,
-    result: null,
-    message: 'Please Upgrade to Premium  Version to have full features',
-  });
+  try {
+    const id = Number(req.params.id || req.body.id);
+    const { email, subject = 'Payment Receipt from Idurar', name = '' } =
+      req.body || {};
+
+    if (!id) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        message: 'Payment id is required',
+      });
+    }
+
+    const paymentRepo = AppDataSource.getRepository('Payment');
+    const payment = await paymentRepo.findOne({ where: { id } });
+
+    if (!payment) {
+      return res.status(404).json({
+        success: false,
+        result: null,
+        message: 'Payment not found',
+      });
+    }
+
+    let to = email;
+    let clientName = name;
+
+    if (!to && payment.client) {
+      const clientRepo = AppDataSource.getRepository('Client');
+      const client = await clientRepo.findOne({ where: { id: payment.client } });
+      to = client ? client.email : to;
+      clientName = client ? client.name : clientName;
+    }
+
+    if (!to) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        message: 'Recipient email is required',
+      });
+    }
+
+    const fileId = `payment-${payment.id}.pdf`;
+    const folderPath = path.join('src', 'public', 'download', 'payment');
+    const targetLocation = path.join(folderPath, fileId);
+
+    fs.mkdirSync(folderPath, { recursive: true });
+
+    await custom.generatePdf(
+      'payment',
+      { filename: 'payment', format: 'A4', targetLocation },
+      payment
+    );
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const html = SendPaymentReceipt({
+      title: subject,
+      name: clientName,
+      time: new Date(),
+    });
+
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to,
+      subject,
+      html,
+      attachments: [
+        {
+          filename: fileId,
+          path: targetLocation,
+        },
+      ],
+    });
+
+    return res.status(200).json({
+      success: true,
+      result: null,
+      message: 'Email sent successfully',
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      result: null,
+      message: error.message,
+    });
+  }
 };
 
 module.exports = mail;

--- a/backend/src/controllers/appControllers/quoteController/sendMail.js
+++ b/backend/src/controllers/appControllers/quoteController/sendMail.js
@@ -1,9 +1,102 @@
+const nodemailer = require('nodemailer');
+const path = require('path');
+const fs = require('fs');
+
+const { AppDataSource } = require('@/typeorm-data-source');
+const custom = require('@/controllers/pdfController');
+const { SendQuote } = require('@/emailTemplate/SendEmailTemplate');
+
 const mail = async (req, res) => {
-  return res.status(200).json({
-    success: true,
-    result: null,
-    message: 'Please Upgrade to Premium  Version to have full features',
-  });
+  try {
+    const id = Number(req.params.id || req.body.id);
+    const { email, subject = 'Quote from Idurar', name = '' } = req.body || {};
+
+    if (!id) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        message: 'Quote id is required',
+      });
+    }
+
+    const quoteRepo = AppDataSource.getRepository('Quote');
+    const quote = await quoteRepo.findOne({ where: { id } });
+
+    if (!quote) {
+      return res.status(404).json({
+        success: false,
+        result: null,
+        message: 'Quote not found',
+      });
+    }
+
+    let to = email;
+    let clientName = name;
+
+    if (!to && quote.client) {
+      const clientRepo = AppDataSource.getRepository('Client');
+      const client = await clientRepo.findOne({ where: { id: quote.client } });
+      to = client ? client.email : to;
+      clientName = client ? client.name : clientName;
+    }
+
+    if (!to) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        message: 'Recipient email is required',
+      });
+    }
+
+    const fileId = `quote-${quote.id}.pdf`;
+    const folderPath = path.join('src', 'public', 'download', 'quote');
+    const targetLocation = path.join(folderPath, fileId);
+
+    fs.mkdirSync(folderPath, { recursive: true });
+
+    await custom.generatePdf(
+      'quote',
+      { filename: 'quote', format: 'A4', targetLocation },
+      quote
+    );
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const html = SendQuote({ title: subject, name: clientName, time: new Date() });
+
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to,
+      subject,
+      html,
+      attachments: [
+        {
+          filename: fileId,
+          path: targetLocation,
+        },
+      ],
+    });
+
+    return res.status(200).json({
+      success: true,
+      result: null,
+      message: 'Email sent successfully',
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      result: null,
+      message: error.message,
+    });
+  }
 };
 
 module.exports = mail;

--- a/backend/tests/sendMail.test.js
+++ b/backend/tests/sendMail.test.js
@@ -1,0 +1,63 @@
+jest.mock('nodemailer');
+jest.mock('@/controllers/pdfController', () => {
+  const fs = require('fs');
+  const path = require('path');
+  return {
+    generatePdf: jest.fn((model, info, result, cb) => {
+      fs.mkdirSync(path.dirname(info.targetLocation), { recursive: true });
+      fs.writeFileSync(info.targetLocation, 'PDF');
+      if (cb) cb();
+    }),
+  };
+});
+
+const nodemailer = require('nodemailer');
+const { AppDataSource } = require('../src/typeorm-data-source');
+
+describe('sendMail controllers', () => {
+  const transport = { sendMail: jest.fn().mockResolvedValue({}) };
+
+  beforeEach(() => {
+    nodemailer.createTransport.mockReturnValue(transport);
+    transport.sendMail.mockClear();
+
+    process.env.SMTP_HOST = 'smtp.test';
+    process.env.SMTP_PORT = '587';
+    process.env.SMTP_SECURE = 'false';
+    process.env.SMTP_USER = 'user@test';
+    process.env.SMTP_PASS = 'pass';
+    process.env.SMTP_FROM = 'from@test';
+
+    AppDataSource.getRepository = jest.fn(() => ({
+      findOne: jest.fn().mockResolvedValue({ id: 1 }),
+    }));
+  });
+
+  test.each([
+    ['invoice', '../src/controllers/appControllers/invoiceController/sendMail', 'invoice-1.pdf'],
+    ['quote', '../src/controllers/appControllers/quoteController/sendMail', 'quote-1.pdf'],
+    ['payment', '../src/controllers/appControllers/paymentController/sendMail', 'payment-1.pdf'],
+  ])('%s sendMail sends email with attachment', async (name, modulePath, filename) => {
+    const sendMail = require(modulePath);
+    const req = {
+      params: { id: 1 },
+      body: { email: 'client@example.com', subject: 'Test' },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await sendMail(req, res);
+
+    expect(nodemailer.createTransport).toHaveBeenCalled();
+    expect(transport.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'client@example.com',
+        attachments: [expect.objectContaining({ filename })],
+      })
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+


### PR DESCRIPTION
## Summary
- use nodemailer to email invoice, quote, and payment PDFs with HTML templates
- expose SMTP environment configuration
- test mail controllers with mocked transport

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f5f79e548333baae2ab522a83321