### PR TITLE
feat: add product CRUD with filters

### DIFF
--- a/frontend/src/modules/ProductModule/CreateProductModule/index.jsx
+++ b/frontend/src/modules/ProductModule/CreateProductModule/index.jsx
@@ -5,6 +5,7 @@ import { ArrowLeftOutlined, CloseCircleOutlined, PlusOutlined } from '@ant-desig
 import { useNavigate } from 'react-router-dom';
 import ProductForm from '../ProductForm';
 import useLanguage from '@/locale/useLanguage';
+import { createProduct } from '@/services/product.service';
 
 export default function CreateProductModule({ config }) {
   const translate = useLanguage();
@@ -14,11 +15,7 @@ export default function CreateProductModule({ config }) {
 
   const onFinish = async (values) => {
     try {
-      await fetch(`/api/${entity}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(values),
-      });
+      await createProduct(values);
       navigate(`/${entity}`);
     } catch (err) {
       console.error(err);

--- a/frontend/src/modules/ProductModule/ProductDataTableModule/index.jsx
+++ b/frontend/src/modules/ProductModule/ProductDataTableModule/index.jsx
@@ -1,10 +1,183 @@
+import React, { useEffect, useState } from 'react';
+import { Table, Button, Drawer, Input, Space, Form } from 'antd';
+import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { ErpLayout } from '@/layout';
-import ErpPanel from '@/modules/ErpPanelModule';
+import ProductForm from '../ProductForm';
+import {
+  getProducts,
+  createProduct,
+  updateProduct,
+  deleteProduct,
+} from '@/services/product.service';
 
-export default function ProductDataTableModule({ config }) {
+export default function ProductDataTableModule() {
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editing, setEditing] = useState(null);
+  const [search, setSearch] = useState('');
+  const [pagination, setPagination] = useState({ current: 1, pageSize: 10, total: 0 });
+  const [sorter, setSorter] = useState({});
+  const [form] = Form.useForm();
+
+  const load = async () => {
+    setLoading(true);
+    const data = await getProducts();
+    if (data.success) {
+      setProducts(data.result);
+      setPagination((p) => ({ ...p, total: data.result.length }));
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleTableChange = (pag, filters, sort) => {
+    setPagination(pag);
+    setSorter(sort);
+  };
+
+  const handleSubmit = async (values) => {
+    if (editing) {
+      await updateProduct(editing.id, values);
+    } else {
+      await createProduct(values);
+    }
+    setDrawerOpen(false);
+    setEditing(null);
+    form.resetFields();
+    load();
+  };
+
+  const handleDelete = async (record) => {
+    await deleteProduct(record.id);
+    load();
+  };
+
+  const filtered = products.filter((p) => {
+    const term = search.toLowerCase();
+    return (
+      p.name.toLowerCase().includes(term) ||
+      (p.sku && p.sku.toLowerCase().includes(term))
+    );
+  });
+
+  const columns = [
+    {
+      title: 'SKU',
+      dataIndex: 'sku',
+      sorter: (a, b) => a.sku.localeCompare(b.sku),
+      sortOrder: sorter.field === 'sku' && sorter.order,
+    },
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      sorter: (a, b) => a.name.localeCompare(b.name),
+      sortOrder: sorter.field === 'name' && sorter.order,
+    },
+    {
+      title: 'Price',
+      dataIndex: 'price',
+      sorter: (a, b) => a.price - b.price,
+      sortOrder: sorter.field === 'price' && sorter.order,
+    },
+    {
+      title: 'Stock',
+      dataIndex: 'stock',
+      sorter: (a, b) => a.stock - b.stock,
+      sortOrder: sorter.field === 'stock' && sorter.order,
+    },
+    {
+      title: 'Min Stock',
+      dataIndex: 'minStock',
+      sorter: (a, b) => a.minStock - b.minStock,
+      sortOrder: sorter.field === 'minStock' && sorter.order,
+    },
+    {
+      title: 'Average Cost',
+      dataIndex: 'averageCost',
+      sorter: (a, b) => a.averageCost - b.averageCost,
+      sortOrder: sorter.field === 'averageCost' && sorter.order,
+    },
+    { title: 'Description', dataIndex: 'description' },
+    {
+      title: 'Action',
+      key: 'action',
+      render: (_, record) => (
+        <Space>
+          <Button
+            icon={<EditOutlined />}
+            onClick={() => {
+              setEditing(record);
+              form.setFieldsValue(record);
+              setDrawerOpen(true);
+            }}
+          />
+          <Button
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => handleDelete(record)}
+          />
+        </Space>
+      ),
+    },
+  ];
+
   return (
     <ErpLayout>
-      <ErpPanel config={config}></ErpPanel>
+      <Space style={{ marginBottom: 16 }}>
+        <Input.Search
+          placeholder="Search by SKU or name"
+          allowClear
+          onSearch={(val) => setSearch(val)}
+          style={{ width: 300 }}
+        />
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={() => {
+            setEditing(null);
+            form.resetFields();
+            setDrawerOpen(true);
+          }}
+        >
+          Add Product
+        </Button>
+      </Space>
+      <Table
+        rowKey="id"
+        dataSource={filtered}
+        columns={columns}
+        loading={loading}
+        pagination={pagination}
+        onChange={handleTableChange}
+        scroll={{ x: 'max-content' }}
+      />
+      <Drawer
+        title={editing ? 'Edit Product' : 'Add Product'}
+        width={480}
+        open={drawerOpen}
+        destroyOnClose
+        onClose={() => {
+          setDrawerOpen(false);
+          setEditing(null);
+        }}
+      >
+        <Form
+          layout="vertical"
+          form={form}
+          onFinish={handleSubmit}
+          initialValues={editing || {}}
+        >
+          <ProductForm />
+          <Button type="primary" onClick={() => form.submit()}>
+            Save
+          </Button>
+        </Form>
+      </Drawer>
     </ErpLayout>
   );
 }
+

--- a/frontend/src/modules/ProductModule/ProductForm.jsx
+++ b/frontend/src/modules/ProductModule/ProductForm.jsx
@@ -8,7 +8,13 @@ export default function ProductForm() {
       <Form.Item
         label="SKU"
         name="sku"
-        rules={[{ required: true, message: 'SKU is required' }]}
+        rules={[
+          { required: true, message: 'SKU is required' },
+          {
+            pattern: /^[A-Za-z0-9_-]+$/,
+            message: 'SKU must be alphanumeric',
+          },
+        ]}
       >
         <Input />
       </Form.Item>
@@ -23,7 +29,10 @@ export default function ProductForm() {
         label="Price"
         name="price"
         initialValue={0}
-        rules={[{ required: true, message: 'Price is required' }]}
+        rules={[
+          { required: true, message: 'Price is required' },
+          { type: 'number', min: 0, message: 'Price must be at least 0' },
+        ]}
       >
         <InputNumber style={{ width: '100%' }} min={0} />
       </Form.Item>
@@ -31,7 +40,10 @@ export default function ProductForm() {
         label="Stock"
         name="stock"
         initialValue={0}
-        rules={[{ required: true, message: 'Stock is required' }]}
+        rules={[
+          { required: true, message: 'Stock is required' },
+          { type: 'number', min: 0, message: 'Stock must be at least 0' },
+        ]}
       >
         <InputNumber style={{ width: '100%' }} min={0} />
       </Form.Item>
@@ -39,7 +51,10 @@ export default function ProductForm() {
         label="Min Stock"
         name="minStock"
         initialValue={0}
-        rules={[{ required: true, message: 'Min stock is required' }]}
+        rules={[
+          { required: true, message: 'Min stock is required' },
+          { type: 'number', min: 0, message: 'Min stock must be at least 0' },
+        ]}
       >
         <InputNumber style={{ width: '100%' }} min={0} />
       </Form.Item>
@@ -47,7 +62,10 @@ export default function ProductForm() {
         label="Average Cost"
         name="averageCost"
         initialValue={0}
-        rules={[{ required: true, message: 'Average cost is required' }]}
+        rules={[
+          { required: true, message: 'Average cost is required' },
+          { type: 'number', min: 0, message: 'Average cost must be at least 0' },
+        ]}
       >
         <InputNumber style={{ width: '100%' }} min={0} />
       </Form.Item>

--- a/frontend/src/modules/ProductModule/UpdateProductModule/index.jsx
+++ b/frontend/src/modules/ProductModule/UpdateProductModule/index.jsx
@@ -1,11 +1,61 @@
+import { useEffect } from 'react';
 import { ErpLayout } from '@/layout';
-import UpdateItem from '@/modules/ErpPanelModule/UpdateItem';
+import { PageHeader } from '@ant-design/pro-layout';
+import { Tag, Button, Form, Divider } from 'antd';
+import { ArrowLeftOutlined, CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { useNavigate, useParams } from 'react-router-dom';
 import ProductForm from '../ProductForm';
+import useLanguage from '@/locale/useLanguage';
+import { getProduct, updateProduct } from '@/services/product.service';
 
 export default function UpdateProductModule({ config }) {
+  const translate = useLanguage();
+  const navigate = useNavigate();
+  const [form] = Form.useForm();
+  const entity = config?.entity || 'products';
+  const { id } = useParams();
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await getProduct(id);
+      if (data.success) {
+        form.setFieldsValue(data.result);
+      }
+    };
+    load();
+  }, [id]);
+
+  const onFinish = async (values) => {
+    try {
+      await updateProduct(id, values);
+      navigate(`/${entity}`);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <ErpLayout>
-      <UpdateItem config={config} UpdateForm={ProductForm} />
+      <PageHeader
+        onBack={() => navigate(`/${entity}`)}
+        backIcon={<ArrowLeftOutlined />}
+        title={translate('Update')}
+        ghost={false}
+        tags={<Tag>{translate('Draft')}</Tag>}
+        extra={[
+          <Button key="cancel" onClick={() => navigate(`/${entity}`)} icon={<CloseCircleOutlined />}> 
+            {translate('Cancel')}
+          </Button>,
+          <Button key="save" type="primary" icon={<PlusOutlined />} onClick={() => form.submit()}>
+            {translate('Save')}
+          </Button>,
+        ]}
+        style={{ padding: '20px 0px' }}
+      />
+      <Divider dashed />
+      <Form form={form} layout="vertical" onFinish={onFinish}>
+        <ProductForm />
+      </Form>
     </ErpLayout>
   );
 }

--- a/frontend/src/pages/Product/index.jsx
+++ b/frontend/src/pages/Product/index.jsx
@@ -1,28 +1,5 @@
-import useLanguage from '@/locale/useLanguage';
 import { ProductDataTableModule } from '@/modules/ProductModule';
 
 export default function Product() {
-  const translate = useLanguage();
-  const entity = 'products';
-
-  const dataTableColumns = [
-    { title: translate('SKU'), dataIndex: 'sku' },
-    { title: translate('Name'), dataIndex: 'name' },
-    { title: translate('Price'), dataIndex: 'price' },
-    { title: translate('Stock'), dataIndex: 'stock' },
-    { title: translate('Min Stock'), dataIndex: 'minStock' },
-    { title: translate('Average Cost'), dataIndex: 'averageCost' },
-    { title: translate('Description'), dataIndex: 'description' },
-  ];
-
-  const Labels = {
-    PANEL_TITLE: translate('product'),
-    DATATABLE_TITLE: translate('product_list'),
-    ADD_NEW_ENTITY: translate('add_new_product'),
-    ENTITY_NAME: translate('product'),
-  };
-
-  const config = { entity, ...Labels, dataTableColumns };
-
-  return <ProductDataTableModule config={config} />;
+  return <ProductDataTableModule />;
 }

--- a/frontend/src/services/product.service.js
+++ b/frontend/src/services/product.service.js
@@ -1,0 +1,27 @@
+import api from '@/request/axios';
+
+export const getProducts = async (params = {}) => {
+  const { data } = await api.get('products', { params });
+  return data;
+};
+
+export const createProduct = async (values) => {
+  const { data } = await api.post('products', values);
+  return data;
+};
+
+export const updateProduct = async (id, values) => {
+  const { data } = await api.patch(`products/${id}`, values);
+  return data;
+};
+
+export const deleteProduct = async (id) => {
+  const { data } = await api.delete(`products/${id}`);
+  return data;
+};
+
+export const getProduct = async (id) => {
+  const { data } = await api.get(`products/${id}`);
+  return data;
+};
+


### PR DESCRIPTION
## Summary
- add product service and integrate API for product CRUD
- implement product table with search, pagination, sorting and drawer forms
- enhance product form validation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe8b32cc83339f8df2a53b71af4a