### PR TITLE
feat: add purchase form table and stock refresh

### DIFF
--- a/frontend/src/modules/PurchaseModule/CreatePurchaseModule/index.jsx
+++ b/frontend/src/modules/PurchaseModule/CreatePurchaseModule/index.jsx
@@ -7,6 +7,7 @@ import PurchaseForm from '../PurchaseForm';
 import useLanguage from '@/locale/useLanguage';
 import calculate from '@/utils/calculate';
 import { useState } from 'react';
+import { request } from '@/request';
 
 export default function CreatePurchaseModule({ config }) {
   const translate = useLanguage();
@@ -23,11 +24,8 @@ export default function CreatePurchaseModule({ config }) {
       items: values.items?.map((i) => ({ product: i.product, quantity: i.quantity, cost: i.cost })),
     };
     try {
-      await fetch('/api/purchases', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
+      await request.post({ entity: 'purchases', jsonData: payload });
+      window.dispatchEvent(new Event('stockUpdate'));
       navigate(`/${entity}`);
     } catch (err) {
       console.error(err);

--- a/frontend/src/modules/PurchaseModule/PurchaseForm.jsx
+++ b/frontend/src/modules/PurchaseModule/PurchaseForm.jsx
@@ -1,4 +1,4 @@
-import { Row, Col, Form, Input, InputNumber, Button, Divider, DatePicker } from 'antd';
+import { Row, Col, Form, Input, InputNumber, Button, Divider, DatePicker, Table } from 'antd';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import SelectAsync from '@/components/SelectAsync';
@@ -33,66 +33,77 @@ export default function PurchaseForm() {
         </Col>
       </Row>
       <Divider dashed />
-      <Row gutter={[12, 0]}>
-        <Col span={8}>
-          <p>Product</p>
-        </Col>
-        <Col span={4}>
-          <p>Quantity</p>
-        </Col>
-        <Col span={4}>
-          <p>Cost</p>
-        </Col>
-        <Col span={4}>
-          <p>Total</p>
-        </Col>
-      </Row>
       <Form.List name="items">
-        {(fields, { add, remove }) => (
-          <>
-            {fields.map((field) => (
-              <Row key={field.key} gutter={[12, 12]} style={{ position: 'relative' }}>
-                <Col span={8}>
-                  <Form.Item
-                    name={[field.name, 'product']}
-                    rules={[{ required: true, message: 'Product is required' }]}
-                  >
-                    <SelectAsync entity={'products'} outputValue={'id'} displayLabels={['name']} />
-                  </Form.Item>
-                </Col>
-                <Col span={4}>
-                  <Form.Item
-                    name={[field.name, 'quantity']}
-                    rules={[{ required: true, message: 'Quantity is required' }]}
-                  >
-                    <InputNumber min={0} style={{ width: '100%' }} />
-                  </Form.Item>
-                </Col>
-                <Col span={4}>
-                  <Form.Item
-                    name={[field.name, 'cost']}
-                    rules={[{ required: true, message: 'Cost is required' }]}
-                  >
-                    <InputNumber min={0} style={{ width: '100%' }} />
-                  </Form.Item>
-                </Col>
-                <Col span={4}>
-                  <Form.Item name={[field.name, 'total']}>
-                    <InputNumber readOnly min={0} style={{ width: '100%' }} />
-                  </Form.Item>
-                </Col>
-                <div style={{ position: 'absolute', right: '-20px', top: '5px' }}>
-                  <DeleteOutlined onClick={() => remove(field.name)} />
-                </div>
-              </Row>
-            ))}
-            <Form.Item>
-              <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
-                Add Item
-              </Button>
-            </Form.Item>
-          </>
-        )}
+        {(fields, { add, remove }) => {
+          const columns = [
+            {
+              title: 'Product',
+              dataIndex: 'product',
+              render: (_, record) => (
+                <Form.Item
+                  name={[record.name, 'product']}
+                  rules={[{ required: true, message: 'Product is required' }]}
+                  style={{ marginBottom: 0 }}
+                >
+                  <SelectAsync entity={'products'} outputValue={'id'} displayLabels={['name']} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Quantity',
+              dataIndex: 'quantity',
+              render: (_, record) => (
+                <Form.Item
+                  name={[record.name, 'quantity']}
+                  rules={[{ required: true, message: 'Quantity is required' }]}
+                  style={{ marginBottom: 0 }}
+                >
+                  <InputNumber min={0} style={{ width: '100%' }} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Cost',
+              dataIndex: 'cost',
+              render: (_, record) => (
+                <Form.Item
+                  name={[record.name, 'cost']}
+                  rules={[{ required: true, message: 'Cost is required' }]}
+                  style={{ marginBottom: 0 }}
+                >
+                  <InputNumber min={0} style={{ width: '100%' }} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Total',
+              dataIndex: 'total',
+              render: (_, record) => (
+                <Form.Item name={[record.name, 'total']} style={{ marginBottom: 0 }}>
+                  <InputNumber readOnly min={0} style={{ width: '100%' }} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: '',
+              dataIndex: 'actions',
+              render: (_, record) => (
+                <DeleteOutlined onClick={() => remove(record.name)} />
+              ),
+            },
+          ];
+
+          return (
+            <>
+              <Table pagination={false} dataSource={fields} columns={columns} rowKey="key" />
+              <Form.Item>
+                <Button type="dashed" onClick={() => add()} block icon={<PlusOutlined />}>
+                  Add Item
+                </Button>
+              </Form.Item>
+            </>
+          );
+        }}
       </Form.List>
     </>
   );

--- a/frontend/src/modules/StockModule/index.jsx
+++ b/frontend/src/modules/StockModule/index.jsx
@@ -1,24 +1,30 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import LowStockAlert from './LowStockAlert';
 import StockAdjustmentForm from './StockAdjustmentForm';
 
 const StockModule = () => {
   const [lowStocks, setLowStocks] = useState([]);
 
-  useEffect(() => {
-    const fetchLowStocks = async () => {
-      try {
-        const res = await fetch('/api/stocks/low');
-        const json = await res.json();
-        if (json.success) {
-          setLowStocks(json.result);
-        }
-      } catch (err) {
-        console.error(err);
+  const fetchLowStocks = useCallback(async () => {
+    try {
+      const res = await fetch('/api/stocks/low');
+      const json = await res.json();
+      if (json.success) {
+        setLowStocks(json.result);
       }
-    };
-    fetchLowStocks();
+    } catch (err) {
+      console.error(err);
+    }
   }, []);
+
+  useEffect(() => {
+    fetchLowStocks();
+  }, [fetchLowStocks]);
+
+  useEffect(() => {
+    window.addEventListener('stockUpdate', fetchLowStocks);
+    return () => window.removeEventListener('stockUpdate', fetchLowStocks);
+  }, [fetchLowStocks]);
 
   const handleAdjust = async (data) => {
     try {


### PR DESCRIPTION
## Summary
- build purchase entry form with Ant Design Table to manage items and totals
- submit purchases via API and trigger stock indicator refresh
- update stock module to respond to stock updates

## Testing
- `npm test`
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5fe8e44f0833385f3aac5816285a7