### PR TITLE
Add dashboard alerts for low stock and overdue invoices

### DIFF
--- a/backend/src/controllers/appControllers/dashboardController.js
+++ b/backend/src/controllers/appControllers/dashboardController.js
@@ -1,0 +1,12 @@
+const dashboardService = require('@/services/dashboardService');
+
+const alerts = async (req, res) => {
+  const result = await dashboardService.getAlerts();
+  return res.status(200).json({
+    success: true,
+    result,
+    message: 'Dashboard alerts retrieved successfully',
+  });
+};
+
+module.exports = { alerts };

--- a/backend/src/routes/appRoutes/appApi.js
+++ b/backend/src/routes/appRoutes/appApi.js
@@ -3,6 +3,7 @@ const { catchErrors } = require('@/handlers/errorHandlers');
 const router = express.Router();
 
 const appControllers = require('@/controllers/appControllers');
+const dashboardController = require('@/controllers/appControllers/dashboardController');
 const { routesList } = require('@/models/utils');
 
 const routerApp = (entity, controller) => {
@@ -41,6 +42,8 @@ const routerApp = (entity, controller) => {
       .get(catchErrors(controller['download']));
   }
 };
+
+router.route('/dashboard/alerts').get(catchErrors(dashboardController.alerts));
 
 routesList.forEach(({ entity, controllerName }) => {
   const controller = appControllers[controllerName];

--- a/backend/src/services/dashboardService.js
+++ b/backend/src/services/dashboardService.js
@@ -1,0 +1,24 @@
+const { AppDataSource } = require('@/typeorm-data-source');
+const { In, LessThan } = require('typeorm');
+
+const ProductRepository = AppDataSource.getRepository('Product');
+const InvoiceRepository = AppDataSource.getRepository('Invoice');
+
+const getAlerts = async () => {
+  const lowStockProducts = await ProductRepository.createQueryBuilder('product')
+    .where('product.removed = false')
+    .andWhere('product.stock < product.minStock')
+    .getMany();
+
+  const overdueInvoices = await InvoiceRepository.find({
+    where: {
+      removed: false,
+      paymentStatus: In(['UNPAID', 'PARTIAL']),
+      expiredDate: LessThan(new Date()),
+    },
+  });
+
+  return { lowStockProducts, overdueInvoices };
+};
+
+module.exports = { getAlerts };

--- a/frontend/src/modules/DashboardModule/index.jsx
+++ b/frontend/src/modules/DashboardModule/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { Tag, Row, Col } from 'antd';
+import { Tag, Row, Col, Alert } from 'antd';
 import useLanguage from '@/locale/useLanguage';
 
 import { useMoney } from '@/settings';
@@ -47,6 +47,8 @@ export default function DashboardModule() {
   const { result: clientResult, isLoading: clientLoading } = useFetch(() =>
     api.summary({ entity: 'client' })
   );
+
+  const { result: alerts } = useFetch(() => api.get({ entity: 'dashboard/alerts' }));
 
   useEffect(() => {
     const currency = money_format_settings.default_currency_code || null;
@@ -127,6 +129,22 @@ export default function DashboardModule() {
   if (money_format_settings) {
     return (
       <>
+        {alerts?.lowStockProducts?.length > 0 && (
+          <Alert
+            type="warning"
+            showIcon
+            message={`${alerts.lowStockProducts.length} product(s) below minimum stock`}
+            style={{ marginBottom: 16 }}
+          />
+        )}
+        {alerts?.overdueInvoices?.length > 0 && (
+          <Alert
+            type="error"
+            showIcon
+            message={`${alerts.overdueInvoices.length} invoice(s) overdue`}
+            style={{ marginBottom: 16 }}
+          />
+        )}
         <Row gutter={[32, 32]}>
           <SummaryCard
             title={translate('Invoices')}


### PR DESCRIPTION
## Summary
- expose `/dashboard/alerts` API for low stock products and overdue invoices
- show Ant Design alerts on dashboard when stock is low or invoices are overdue

## Testing
- `npm test`
- `npm run lint` *(fails: ReferenceError: Cannot read config file: /workspace/ERP-Node/frontend/.eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe97c3b88333b713564ff0e45fee