### PR TITLE
Add expense/payroll pages with tabs and category CRUD

### DIFF
--- a/backend/src/routes/expenseRoutes.js
+++ b/backend/src/routes/expenseRoutes.js
@@ -13,7 +13,18 @@ router
   .post(rbac(['owner', 'manager']), catchErrors(expenseController.create));
 
 router
+  .route('/expense')
+  .get(rbac(['owner', 'manager']), catchErrors(expenseController.list))
+  .post(rbac(['owner', 'manager']), catchErrors(expenseController.create));
+
+router
   .route('/expenses/:id')
+  .get(rbac(['owner', 'manager']), catchErrors(expenseController.read))
+  .patch(rbac(['owner', 'manager']), catchErrors(expenseController.update))
+  .delete(rbac(['owner', 'manager']), catchErrors(expenseController.delete));
+
+router
+  .route('/expense/:id')
   .get(rbac(['owner', 'manager']), catchErrors(expenseController.read))
   .patch(rbac(['owner', 'manager']), catchErrors(expenseController.update))
   .delete(rbac(['owner', 'manager']), catchErrors(expenseController.delete));

--- a/frontend/src/components/CategorySelect/index.jsx
+++ b/frontend/src/components/CategorySelect/index.jsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react';
+import { Select, Button, Modal, Form, Input, List, Space } from 'antd';
+import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import useLanguage from '@/locale/useLanguage';
+
+export default function CategorySelect({ value, onChange }) {
+  const translate = useLanguage();
+  const [categories, setCategories] = useState([]);
+  const [open, setOpen] = useState(false);
+  const [editingId, setEditingId] = useState(null);
+  const [editName, setEditName] = useState('');
+
+  const fetchCategories = () => {
+    fetch('/api/expensecategory')
+      .then((res) => res.json())
+      .then((data) => setCategories(data.result || []));
+  };
+
+  useEffect(() => {
+    fetchCategories();
+  }, []);
+
+  const addCategory = async (values) => {
+    await fetch('/api/expensecategory', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+    fetchCategories();
+  };
+
+  const updateCategory = async (id) => {
+    await fetch(`/api/expensecategory/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: editName }),
+    });
+    setEditingId(null);
+    setEditName('');
+    fetchCategories();
+  };
+
+  const deleteCategory = async (id) => {
+    await fetch(`/api/expensecategory/${id}`, { method: 'DELETE' });
+    fetchCategories();
+  };
+
+  const options = categories.map((c) => ({ value: c.id, label: c.name }));
+
+  return (
+    <>
+      <Select
+        value={value}
+        onChange={onChange}
+        options={options}
+        dropdownRender={(menu) => (
+          <>
+            {menu}
+            <Button
+              type="link"
+              icon={<PlusOutlined />}
+              onClick={() => setOpen(true)}
+              style={{ width: '100%', textAlign: 'left' }}
+            >
+              {translate('expense_category')}
+            </Button>
+          </>
+        )}
+      />
+      <Modal open={open} onCancel={() => setOpen(false)} footer={null} title={translate('expense_category')}>
+        <Form layout="inline" onFinish={addCategory} style={{ marginBottom: 16 }}>
+          <Form.Item name="name" rules={[{ required: true }]}> 
+            <Input placeholder={translate('expense_category')} />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit">
+              {translate('add')}
+            </Button>
+          </Form.Item>
+        </Form>
+        <List
+          dataSource={categories}
+          renderItem={(item) => (
+            <List.Item
+              actions={[
+                editingId === item.id ? (
+                  <Space>
+                    <Button type="link" onClick={() => updateCategory(item.id)}>
+                      {translate('save')}
+                    </Button>
+                    <Button type="link" onClick={() => setEditingId(null)}>
+                      {translate('cancel')}
+                    </Button>
+                  </Space>
+                ) : (
+                  <Button
+                    type="link"
+                    icon={<EditOutlined />}
+                    onClick={() => {
+                      setEditingId(item.id);
+                      setEditName(item.name);
+                    }}
+                  />
+                ),
+                <Button
+                  danger
+                  type="link"
+                  icon={<DeleteOutlined />}
+                  onClick={() => deleteCategory(item.id)}
+                />, 
+              ]}
+            >
+              {editingId === item.id ? (
+                <Input value={editName} onChange={(e) => setEditName(e.target.value)} />
+              ) : (
+                item.name
+              )}
+            </List.Item>
+          )}
+        />
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/modules/ExpenseModule/CreateExpenseModule/index.jsx
+++ b/frontend/src/modules/ExpenseModule/CreateExpenseModule/index.jsx
@@ -2,7 +2,7 @@ import ExpenseForm from '../ExpenseForm';
 
 const CreateExpenseModule = () => {
   const handleSubmit = async (data) => {
-    await fetch('/api/expenses', {
+    await fetch('/api/expense', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),

--- a/frontend/src/modules/ExpenseModule/ExpenseForm.jsx
+++ b/frontend/src/modules/ExpenseModule/ExpenseForm.jsx
@@ -1,36 +1,50 @@
-import { useEffect, useState } from 'react';
-import { z } from 'zod';
-import RHFForm from '@/forms/RHFForm';
-import RHFInput from '@/forms/RHFInput';
-import RHFSelect from '@/forms/RHFSelect';
+import dayjs from 'dayjs';
+import { Form, Input, InputNumber, DatePicker, Button } from 'antd';
 import useLanguage from '@/locale/useLanguage';
-
-const schema = z.object({
-  amount: z.number().min(0, 'Amount is required'),
-  description: z.string().min(1, 'Description is required'),
-  category: z.number({ required_error: 'Category is required' }),
-});
+import { useDate } from '@/settings';
+import CategorySelect from '@/components/CategorySelect';
 
 export default function ExpenseForm({ onSubmit }) {
+  const [form] = Form.useForm();
   const translate = useLanguage();
-  const [categories, setCategories] = useState([]);
+  const { dateFormat } = useDate();
 
-  useEffect(() => {
-    fetch('/api/expensecategory')
-      .then((res) => res.json())
-      .then((data) => setCategories(data.result || []));
-  }, []);
-
-  const defaultValues = { amount: 0, description: '', category: '' };
-
-  const options = categories.map((cat) => ({ value: cat.id, label: cat.name }));
+  const handleFinish = (values) => {
+    onSubmit({
+      ...values,
+      date: values.date.format('YYYY-MM-DD'),
+    });
+    form.resetFields();
+  };
 
   return (
-    <RHFForm schema={schema} defaultValues={defaultValues} onSubmit={onSubmit}>
-      <RHFInput name="amount" type="number" label={translate('Amount')} />
-      <RHFInput name="description" label={translate('Description')} />
-      <RHFSelect name="category" label={translate('expense_category')} options={options} />
-      <button type="submit">{translate('save')}</button>
-    </RHFForm>
+    <Form form={form} layout="vertical" onFinish={handleFinish}>
+      <Form.Item
+        name="amount"
+        label={translate('Amount')}
+        rules={[{ required: true }]}
+      >
+        <InputNumber style={{ width: '100%' }} min={0} />
+      </Form.Item>
+      <Form.Item
+        name="date"
+        label={translate('Date')}
+        rules={[{ required: true }]}
+        initialValue={dayjs()}
+      >
+        <DatePicker format={dateFormat} style={{ width: '100%' }} />
+      </Form.Item>
+      <Form.Item name="category" label={translate('expense_category')}>
+        <CategorySelect />
+      </Form.Item>
+      <Form.Item name="description" label={translate('Description')}>
+        <Input />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          {translate('Save')}
+        </Button>
+      </Form.Item>
+    </Form>
   );
 }

--- a/frontend/src/modules/PayrollModule/CreatePayrollModule/index.jsx
+++ b/frontend/src/modules/PayrollModule/CreatePayrollModule/index.jsx
@@ -2,7 +2,7 @@ import PayrollForm from '../PayrollForm';
 
 const CreatePayrollModule = () => {
   const handleSubmit = async (data) => {
-    await fetch('/api/payroll/create', {
+    await fetch('/api/payroll', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),

--- a/frontend/src/modules/PayrollModule/PayrollForm.jsx
+++ b/frontend/src/modules/PayrollModule/PayrollForm.jsx
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { Form, Input, InputNumber, Button, DatePicker } from 'antd';
 import SelectAsync from '@/components/SelectAsync';
+import CategorySelect from '@/components/CategorySelect';
 import useLanguage from '@/locale/useLanguage';
 import { useDate } from '@/settings';
 
@@ -48,7 +49,7 @@ export default function PayrollForm({ onSubmit }) {
         label={translate('expense_category')}
         rules={[{ required: true }]}
       >
-        <SelectAsync entity="expenseCategory" displayLabels={['name']} />
+        <CategorySelect />
       </Form.Item>
 
       <Form.Item name="description" label={translate('Description')}>

--- a/frontend/src/pages/Expense/index.jsx
+++ b/frontend/src/pages/Expense/index.jsx
@@ -1,7 +1,8 @@
 import dayjs from 'dayjs';
 import useLanguage from '@/locale/useLanguage';
 import { useDate } from '@/settings';
-import { ExpenseDataTableModule } from '@/modules/ExpenseModule';
+import { Tabs } from 'antd';
+import { ExpenseDataTableModule, CreateExpenseModule } from '@/modules/ExpenseModule';
 
 export default function Expense() {
   const translate = useLanguage();
@@ -36,5 +37,18 @@ export default function Expense() {
 
   const config = { entity, ...Labels, dataTableColumns, searchConfig };
 
-  return <ExpenseDataTableModule config={config} />;
+  const items = [
+    {
+      key: 'list',
+      label: translate('expense_list'),
+      children: <ExpenseDataTableModule config={config} />,
+    },
+    {
+      key: 'create',
+      label: translate('add_new_expense'),
+      children: <CreateExpenseModule />,
+    },
+  ];
+
+  return <Tabs items={items} />;
 }

--- a/frontend/src/pages/Payroll/index.jsx
+++ b/frontend/src/pages/Payroll/index.jsx
@@ -1,10 +1,10 @@
 import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
-import { Card, Table } from 'antd';
+import { Card, Table, Tabs } from 'antd';
 import { Link } from 'react-router-dom';
 import useLanguage from '@/locale/useLanguage';
 import { useDate } from '@/settings';
-import { PayrollDataTableModule } from '@/modules/PayrollModule';
+import { PayrollDataTableModule, CreatePayrollModule } from '@/modules/PayrollModule';
 import { request } from '@/request';
 
 export default function Payroll() {
@@ -41,6 +41,19 @@ export default function Payroll() {
 
   const config = { entity, ...Labels, dataTableColumns };
 
+  const items = [
+    {
+      key: 'list',
+      label: translate('payroll_list'),
+      children: <PayrollDataTableModule config={config} />,
+    },
+    {
+      key: 'create',
+      label: translate('add_new_payroll'),
+      children: <CreatePayrollModule />,
+    },
+  ];
+
   return (
     <>
       {summary.length > 0 && (
@@ -65,7 +78,7 @@ export default function Payroll() {
           />
         </Card>
       )}
-      <PayrollDataTableModule config={config} />
+      <Tabs items={items} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- build reusable CategorySelect with CRUD support
- redesign Expense and Payroll pages using AntD Tabs and Forms
- connect forms to /expense and /payroll APIs with new backend alias

## Testing
- `cd backend && npm test`
- `cd frontend && npm run lint` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe924d4c833393d5d9519ff6eedf