### PR TITLE
Add low stock warning to stock ledger table

### DIFF
--- a/frontend/src/modules/StockLedgerModule/StockLedgerDataTableModule/index.jsx
+++ b/frontend/src/modules/StockLedgerModule/StockLedgerDataTableModule/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Table, DatePicker, Select, Space, Card } from 'antd';
+import { Table, DatePicker, Select, Space, Card, Badge } from 'antd';
 import dayjs from 'dayjs';
 import { request } from '@/request';
 import { ErpLayout } from '@/layout';
@@ -65,7 +65,16 @@ export default function StockLedgerDataTableModule() {
       dataIndex: 'created',
       render: (d) => dayjs(d).format('YYYY-MM-DD'),
     },
-    { title: 'Product', dataIndex: 'productName' },
+    {
+      title: 'Product',
+      dataIndex: 'productName',
+      render: (text, record) =>
+        record.product?.stock < record.product?.minStock ? (
+          <Badge status="warning" text={text} />
+        ) : (
+          text
+        ),
+    },
     { title: 'Type', dataIndex: 'type' },
     { title: 'Qty In', dataIndex: 'qtyIn' },
     { title: 'Qty Out', dataIndex: 'qtyOut' },


### PR DESCRIPTION
## Summary
- flag products below minimum stock with a warning badge in Stock Ledger table

## Testing
- `npm test --prefix backend`
- `npm run lint --prefix frontend` *(fails: module is not defined in .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe90c254833395fdfe3c7268f590