### PR TITLE
feat: avoid 404 when no data

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createCRUDController/read.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/read.js
@@ -6,7 +6,8 @@ const read = async (repository, req, res) => {
     if (hasColumn(repository, 'removed')) where.removed = false;
     const result = await repository.findOne({ where });
     if (!result) {
-      return res.status(404).json({
+      // Return a 200 response with a friendly message instead of 404
+      return res.status(200).json({
         success: false,
         result: null,
         message: 'No document found ',

--- a/backend/src/controllers/middlewaresControllers/createUserController/read.js
+++ b/backend/src/controllers/middlewaresControllers/createUserController/read.js
@@ -6,15 +6,15 @@ const read = async (userModel, req, res) => {
   const tmpResult = await User.findOne({
     where: { id: req.params.id, removed: false },
   });
-  // If no results found, return document not found
+  // If no results found, return a successful response with an empty result
   if (!tmpResult) {
-    return res.status(404).json({
+    return res.status(200).json({
       success: false,
       result: null,
       message: 'No document found ',
     });
   } else {
-    // Return success resposne
+    // Return success response
     let result = {
       _id: tmpResult.id,
       enabled: tmpResult.enabled,


### PR DESCRIPTION
## Summary
- return 200 instead of 404 when no record exists in generic read controllers
- use the same behavior for user read controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b746102e74833381c511c26b477d60