### PR TITLE
Add routes for inventory and expense pages

### DIFF
--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -20,6 +20,14 @@ const QuoteUpdate = lazy(() => import('@/pages/Quote/QuoteUpdate'));
 const Payment = lazy(() => import('@/pages/Payment/index'));
 const PaymentRead = lazy(() => import('@/pages/Payment/PaymentRead'));
 const PaymentUpdate = lazy(() => import('@/pages/Payment/PaymentUpdate'));
+const Products = lazy(() => import('@/pages/Products'));
+const Suppliers = lazy(() => import('@/pages/Suppliers'));
+const PurchaseInvoices = lazy(() => import('@/pages/PurchaseInvoices'));
+const StockLedger = lazy(() => import('@/pages/StockLedger'));
+const ExpenseCategories = lazy(() => import('@/pages/ExpenseCategories'));
+const Expenses = lazy(() => import('@/pages/Expenses'));
+const StockToBuy = lazy(() => import('@/pages/PurchaseInvoices/StockToBuy'));
+const Recap = lazy(() => import('@/pages/Reports/Recap'));
 
 const Settings = lazy(() => import('@/pages/Settings/Settings'));
 const PaymentMode = lazy(() => import('@/pages/PaymentMode'));
@@ -100,6 +108,38 @@ let routes = {
     {
       path: '/payment/update/:id',
       element: <PaymentUpdate />,
+    },
+    {
+      path: '/product',
+      element: <Products />,
+    },
+    {
+      path: '/supplier',
+      element: <Suppliers />,
+    },
+    {
+      path: '/purchaseinvoice',
+      element: <PurchaseInvoices />,
+    },
+    {
+      path: '/stock/ledger',
+      element: <StockLedger />,
+    },
+    {
+      path: '/expense/category',
+      element: <ExpenseCategories />,
+    },
+    {
+      path: '/expense',
+      element: <Expenses />,
+    },
+    {
+      path: '/purchaseinvoice/stock-to-buy',
+      element: <StockToBuy />,
+    },
+    {
+      path: '/reports/recap',
+      element: <Recap />,
     },
 
     {


### PR DESCRIPTION
## Summary
- add lazy-loaded imports for product, supplier, purchasing, stock, expense, and report pages
- register routes for the new resources while preserving existing redirects and 404 handling

## Testing
- npm run lint -- --help

------
https://chatgpt.com/codex/tasks/task_e_68d0bc3bc3a88333a40c97a352034b18