### PR TITLE
Improve MySQL datasource env configuration

### DIFF
--- a/backend/src/typeorm-data-source.js
+++ b/backend/src/typeorm-data-source.js
@@ -24,13 +24,43 @@ const ExpenseCategory = require('./entities/ExpenseCategory');
 const Expense = require('./entities/Expense');
 const StockLedger = require('./entities/StockLedger');
 
+// Collect environment variables using multiple fallbacks so that the
+// configuration works both with the legacy `DB_*` variables that this project
+// historically used as well as the `MYSQL*` variables exposed by many hosting
+// providers (Railway, Vercel, Render, etc.).
+const getEnv = (keys, defaultValue = undefined) => {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (value !== undefined && value !== '') {
+      return value;
+    }
+  }
+  return defaultValue;
+};
+
+const connectionUrl = getEnv(['DATABASE_URL', 'DB_URL', 'MYSQL_URL']);
+
+// When a connection string is provided we let TypeORM parse it. Otherwise we
+// fall back to the discrete configuration options.
+const connectionConfig = connectionUrl
+  ? {
+      type: 'mysql',
+      url: connectionUrl,
+    }
+  : {
+      type: 'mysql',
+      host: getEnv(['DB_HOST', 'MYSQLHOST', 'MYSQL_HOST'], '127.0.0.1'),
+      port: parseInt(getEnv(['DB_PORT', 'MYSQLPORT', 'MYSQL_PORT'], '3306'), 10),
+      username: getEnv(['DB_USER', 'MYSQLUSER', 'MYSQL_USER'], 'root'),
+      password: getEnv(['DB_PASSWORD', 'MYSQLPASSWORD', 'MYSQL_PASSWORD'], ''),
+      database: getEnv(
+        ['DB_NAME', 'MYSQLDATABASE', 'MYSQL_DB', 'MYSQL_DATABASE'],
+        'erp'
+      ),
+    };
+
 const AppDataSource = new DataSource({
-  type: 'mysql',
-  host: process.env.DB_HOST || 'localhost',
-  port: parseInt(process.env.DB_PORT || '3306'),
-  username: process.env.DB_USER || 'root',
-  password: process.env.DB_PASSWORD || '',
-  database: process.env.DB_NAME || 'erp',
+  ...connectionConfig,
   synchronize: false,
   logging: false,
   entities: [


### PR DESCRIPTION
## Summary
- add helper to resolve MySQL configuration from multiple environment variable names
- support DATABASE_URL connection strings and fall back to common MYSQL_* variables

## Testing
- node -e "require('./backend/src/typeorm-data-source')"


------
https://chatgpt.com/codex/tasks/task_e_68d7d565ce8883339a00fa4693bd8877