### PR TITLE
Run pending TypeORM migrations on startup

### DIFF
--- a/backend/src/seeds/masterDataSeed.ts
+++ b/backend/src/seeds/masterDataSeed.ts
@@ -1,8 +1,8 @@
-import { AppDataSource } from '../typeorm-data-source';
+import { AppDataSource, initializeDataSource } from '../typeorm-data-source';
 
 async function run() {
   try {
-    await AppDataSource.initialize();
+    await initializeDataSource();
     const productRepo = AppDataSource.getRepository('Product');
     const supplierRepo = AppDataSource.getRepository('Supplier');
 

--- a/backend/src/seeds/seed.js
+++ b/backend/src/seeds/seed.js
@@ -1,8 +1,8 @@
-const { AppDataSource } = require('../typeorm-data-source');
+const { AppDataSource, initializeDataSource } = require('../typeorm-data-source');
 
 async function run() {
   try {
-    await AppDataSource.initialize();
+    await initializeDataSource();
     const paymentModeRepo = AppDataSource.getRepository('PaymentMode');
     const count = await paymentModeRepo.count();
     if (count === 0) {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,5 +1,5 @@
 require('module-alias/register');
-const { AppDataSource } = require('./typeorm-data-source');
+const { AppDataSource, initializeDataSource } = require('./typeorm-data-source');
 
 // Make sure we are running node 7.6+
 const [major, minor] = process.versions.node.split('.').map(parseFloat);
@@ -13,7 +13,7 @@ require('dotenv').config({ path: '.env' });
 require('dotenv').config({ path: '.env.local' });
 
 // Initialize database connection then start server
-AppDataSource.initialize()
+initializeDataSource()
   .then(() => {
     console.log('Connected to MySQL');
     const app = require('./app');

--- a/backend/src/setup/reset.js
+++ b/backend/src/setup/reset.js
@@ -1,9 +1,9 @@
 require('dotenv').config({ path: '.env' });
 require('dotenv').config({ path: '.env.local' });
-const { AppDataSource } = require('../typeorm-data-source');
+const { AppDataSource, initializeDataSource } = require('../typeorm-data-source');
 
 async function deleteData() {
-  await AppDataSource.initialize();
+  await initializeDataSource();
   const Admin = AppDataSource.getRepository('Admin');
   const AdminPassword = AppDataSource.getRepository('AdminPassword');
   const Setting = AppDataSource.getRepository('Setting');

--- a/backend/src/setup/setup.js
+++ b/backend/src/setup/setup.js
@@ -4,11 +4,11 @@ const { globSync } = require('glob');
 const fs = require('fs');
 const { generate: uniqueId } = require('shortid');
 const bcrypt = require('bcryptjs');
-const { AppDataSource } = require('../typeorm-data-source');
+const { AppDataSource, initializeDataSource } = require('../typeorm-data-source');
 
 async function setupApp() {
   try {
-    await AppDataSource.initialize();
+    await initializeDataSource();
     const Admin = AppDataSource.getRepository('Admin');
     const AdminPassword = AppDataSource.getRepository('AdminPassword');
     const Setting = AppDataSource.getRepository('Setting');


### PR DESCRIPTION
## Summary
- register the backend migrations with the shared TypeORM data source
- run pending migrations before starting the HTTP server or executing setup/reset scripts
- update seed utilities to reuse the shared data source initializer

## Testing
- not run (database-dependent setup)

------
https://chatgpt.com/codex/tasks/task_e_68d8545dc3c48333b96ee2c04b1f5f74