### PR TITLE
Add migration for purchase invoice items table

### DIFF
--- a/backend/src/migrations/1716000000004-CreatePurchaseInvoiceItemsTable.js
+++ b/backend/src/migrations/1716000000004-CreatePurchaseInvoiceItemsTable.js
@@ -1,0 +1,31 @@
+class CreatePurchaseInvoiceItemsTable1716000000004 {
+  async up(queryRunner) {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS \`purchase_invoice_items\` (
+        \`id\` int NOT NULL AUTO_INCREMENT,
+        \`description\` text NULL,
+        \`quantity\` float NOT NULL DEFAULT 0,
+        \`unitPrice\` float NOT NULL DEFAULT 0,
+        \`discountValue\` float NOT NULL DEFAULT 0,
+        \`discountType\` varchar(20) NOT NULL DEFAULT 'amount',
+        \`total\` float NOT NULL DEFAULT 0,
+        \`removed\` tinyint(1) NOT NULL DEFAULT 0,
+        \`created\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        \`updated\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        \`invoice\` int NOT NULL,
+        \`product\` int NULL,
+        PRIMARY KEY (\`id\`),
+        KEY \`IDX_purchase_invoice_items_invoice\` (\`invoice\`),
+        KEY \`IDX_purchase_invoice_items_product\` (\`product\`),
+        CONSTRAINT \`FK_purchase_invoice_items_invoice\` FOREIGN KEY (\`invoice\`) REFERENCES \`purchase_invoices\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT \`FK_purchase_invoice_items_product\` FOREIGN KEY (\`product\`) REFERENCES \`products\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION
+      ) ENGINE=InnoDB
+    `);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query('DROP TABLE IF EXISTS `purchase_invoice_items`');
+  }
+}
+
+module.exports = CreatePurchaseInvoiceItemsTable1716000000004;


### PR DESCRIPTION
## Summary
- add a migration that creates the `purchase_invoice_items` table with the expected columns and constraints

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8c44d51308333a8ee3d63ccae607a