### PR TITLE
Add removed flag columns to expense tables

### DIFF
--- a/backend/src/migrations/1716000000004-AddRemovedToExpenses.js
+++ b/backend/src/migrations/1716000000004-AddRemovedToExpenses.js
@@ -1,0 +1,27 @@
+class AddRemovedToExpenses1716000000004 {
+  async up(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE \`expense_categories\`
+      ADD COLUMN \`removed\` tinyint(1) NOT NULL DEFAULT 0 AFTER \`description\`
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE \`expenses\`
+      ADD COLUMN \`removed\` tinyint(1) NOT NULL DEFAULT 0 AFTER \`notes\`
+    `);
+  }
+
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE \`expenses\`
+      DROP COLUMN \`removed\`
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE \`expense_categories\`
+      DROP COLUMN \`removed\`
+    `);
+  }
+}
+
+module.exports = AddRemovedToExpenses1716000000004;


### PR DESCRIPTION
## Summary
- add a migration that adds the `removed` flag to the expense and expense category tables so queries filtering on the flag succeed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8c4dd3e5483339240befcd1e855a1