### PR TITLE
Fix ERP data table menu filtering reassignment

### DIFF
--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -48,6 +48,7 @@ export default function DataTable({ config, extra = [] }) {
     searchConfig,
     service,
     disableActions = false,
+    allowedActions,
   } = config;
 
   const { DATATABLE_TITLE } = config;
@@ -59,7 +60,7 @@ export default function DataTable({ config, extra = [] }) {
   const { erpContextAction } = useErpContext();
   const { modal } = erpContextAction;
 
-  const items = disableActions
+  const baseItems = disableActions
     ? []
     : [
         {
@@ -89,18 +90,18 @@ export default function DataTable({ config, extra = [] }) {
         },
       ];
 
-  items = items.filter((item) => {
-    if (item.type === 'divider') return true;
-    if (!allowedActions) return true;
-    return allowedActions.includes(item.key);
-  });
-
-  items = items.filter((item, index, array) => {
-    if (item.type !== 'divider') return true;
-    const prev = array[index - 1];
-    const next = array[index + 1];
-    return prev && prev.type !== 'divider' && next && next.type !== 'divider';
-  });
+  const items = baseItems
+    .filter((item) => {
+      if (item.type === 'divider') return true;
+      if (!allowedActions) return true;
+      return allowedActions.includes(item.key);
+    })
+    .filter((item, index, array) => {
+      if (item.type !== 'divider') return true;
+      const prev = array[index - 1];
+      const next = array[index + 1];
+      return prev && prev.type !== 'divider' && next && next.type !== 'divider';
+    });
 
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Summary
- derive the ERP data table menu items from a base array so filtering no longer reassigns a `const` value and avoids runtime warnings

## Testing
- npm run lint *(fails: Missing script "lint" in the workspace package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68eaa77f35d08333a4dd10739f6e6a99