### PR TITLE
Align product inventory columns with schema

### DIFF
--- a/backend/src/entities/Product.js
+++ b/backend/src/entities/Product.js
@@ -1,5 +1,14 @@
 const { EntitySchema } = require('typeorm');
 
+const decimalTransformer = {
+  to: (value) => (value === null || value === undefined ? 0 : value),
+  from: (value) => {
+    if (value === null || value === undefined) return 0;
+    const numberValue = Number(value);
+    return Number.isNaN(numberValue) ? 0 : numberValue;
+  },
+};
+
 module.exports = new EntitySchema({
   name: 'Product',
   tableName: 'products',
@@ -8,10 +17,28 @@ module.exports = new EntitySchema({
     name: { type: 'varchar', length: 255 },
     sku: { type: 'varchar', length: 100, nullable: true },
     unit: { type: 'varchar', length: 50, default: 'unit' },
-    price: { type: 'decimal', precision: 10, scale: 2, default: 0 },
-    stockQuantity: { type: 'float', default: 0 },
-    lastCostPrice: { type: 'float', default: 0 },
-    lastSellPrice: { type: 'float', default: 0 },
+    price: { type: 'decimal', precision: 10, scale: 2, default: 0, transformer: decimalTransformer },
+    stockQuantity: {
+      type: 'decimal',
+      precision: 12,
+      scale: 2,
+      default: 0,
+      transformer: decimalTransformer,
+    },
+    lastCostPrice: {
+      type: 'decimal',
+      precision: 10,
+      scale: 2,
+      default: 0,
+      transformer: decimalTransformer,
+    },
+    lastSellPrice: {
+      type: 'decimal',
+      precision: 10,
+      scale: 2,
+      default: 0,
+      transformer: decimalTransformer,
+    },
     description: { type: 'text', nullable: true },
     removed: { type: 'boolean', default: false },
     created: { type: 'timestamp', createDate: true, default: () => 'CURRENT_TIMESTAMP' },

--- a/backend/src/migrations/1716000000005-AlignProductInventoryColumns.js
+++ b/backend/src/migrations/1716000000005-AlignProductInventoryColumns.js
@@ -1,0 +1,67 @@
+class AlignProductInventoryColumns1716000000005 {
+  async up(queryRunner) {
+    const tableName = 'products';
+
+    const hasStockQuantity = await queryRunner.hasColumn(tableName, 'stockQuantity');
+    const hasStock = await queryRunner.hasColumn(tableName, 'stock');
+    if (!hasStockQuantity) {
+      if (hasStock) {
+        await queryRunner.query(
+          "ALTER TABLE `products` CHANGE `stock` `stockQuantity` decimal(12,2) NOT NULL DEFAULT '0.00'"
+        );
+      } else {
+        await queryRunner.query(
+          "ALTER TABLE `products` ADD `stockQuantity` decimal(12,2) NOT NULL DEFAULT '0.00'"
+        );
+      }
+    }
+
+    const hasLastCostPrice = await queryRunner.hasColumn(tableName, 'lastCostPrice');
+    const hasCostPrice = await queryRunner.hasColumn(tableName, 'costPrice');
+    if (!hasLastCostPrice) {
+      if (hasCostPrice) {
+        await queryRunner.query(
+          "ALTER TABLE `products` CHANGE `costPrice` `lastCostPrice` decimal(10,2) NOT NULL DEFAULT '0.00'"
+        );
+      } else {
+        await queryRunner.query(
+          "ALTER TABLE `products` ADD `lastCostPrice` decimal(10,2) NOT NULL DEFAULT '0.00'"
+        );
+      }
+    }
+
+    const hasLastSellPrice = await queryRunner.hasColumn(tableName, 'lastSellPrice');
+    if (!hasLastSellPrice) {
+      await queryRunner.query(
+        "ALTER TABLE `products` ADD `lastSellPrice` decimal(10,2) NOT NULL DEFAULT '0.00'"
+      );
+    }
+  }
+
+  async down(queryRunner) {
+    const tableName = 'products';
+
+    const hasLastSellPrice = await queryRunner.hasColumn(tableName, 'lastSellPrice');
+    if (hasLastSellPrice) {
+      await queryRunner.query("ALTER TABLE `products` DROP COLUMN `lastSellPrice`");
+    }
+
+    const hasLastCostPrice = await queryRunner.hasColumn(tableName, 'lastCostPrice');
+    const hasCostPrice = await queryRunner.hasColumn(tableName, 'costPrice');
+    if (hasLastCostPrice && !hasCostPrice) {
+      await queryRunner.query(
+        "ALTER TABLE `products` CHANGE `lastCostPrice` `costPrice` decimal(10,2) NOT NULL DEFAULT '0.00'"
+      );
+    }
+
+    const hasStockQuantity = await queryRunner.hasColumn(tableName, 'stockQuantity');
+    const hasStock = await queryRunner.hasColumn(tableName, 'stock');
+    if (hasStockQuantity && !hasStock) {
+      await queryRunner.query(
+        "ALTER TABLE `products` CHANGE `stockQuantity` `stock` decimal(12,2) NOT NULL DEFAULT '0.00'"
+      );
+    }
+  }
+}
+
+module.exports = AlignProductInventoryColumns1716000000005;

--- a/backend/src/services/stockLedgerService.js
+++ b/backend/src/services/stockLedgerService.js
@@ -15,23 +15,29 @@ const SOURCE_TYPES = {
   ADJUSTMENT: 'adjustment',
 };
 
+const toNumber = (value, fallback = 0) => {
+  if (value === null || value === undefined) return fallback;
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? fallback : numeric;
+};
+
 const recalculateProductAggregates = async (productId) => {
   if (!productId) return null;
   const product = await ProductRepository.findOne({ where: { id: productId, removed: false } });
   if (!product) return null;
 
   const entries = await StockLedgerRepository.find({ where: { product: productId } });
-  let stockQuantity = 0;
-  let lastCostPrice = product.lastCostPrice || 0;
-  let lastSellPrice = product.lastSellPrice || 0;
+  let stockQuantity = toNumber(product.stockQuantity);
+  let lastCostPrice = toNumber(product.lastCostPrice);
+  let lastSellPrice = toNumber(product.lastSellPrice);
 
   entries.forEach((entry) => {
     if (entry.entryType === ENTRY_TYPES.IN) {
-      stockQuantity += entry.quantity;
-      lastCostPrice = entry.costPrice || lastCostPrice;
+      stockQuantity += toNumber(entry.quantity);
+      lastCostPrice = toNumber(entry.costPrice, lastCostPrice);
     } else if (entry.entryType === ENTRY_TYPES.OUT) {
-      stockQuantity -= entry.quantity;
-      lastSellPrice = entry.sellPrice || lastSellPrice;
+      stockQuantity -= toNumber(entry.quantity);
+      lastSellPrice = toNumber(entry.sellPrice, lastSellPrice);
     }
   });
 


### PR DESCRIPTION
## Summary
- add a migration that renames or creates the product inventory columns expected by the application
- update the Product entity to use decimal-backed numeric transformers for inventory and price fields
- ensure stock ledger aggregation normalises decimal values to numbers when calculating totals

## Testing
- Not run (database required)

------
https://chatgpt.com/codex/tasks/task_e_68eab1cd06588333807511e806b55e73