### PR TITLE
Fix stock ledger entry type schema mismatch

### DIFF
--- a/backend/src/migrations/1717000000001-EnsureStockLedgerEntryType.js
+++ b/backend/src/migrations/1717000000001-EnsureStockLedgerEntryType.js
@@ -1,0 +1,33 @@
+class EnsureStockLedgerEntryType1717000000001 {
+  async up(queryRunner) {
+    const tableName = 'stock_ledger';
+
+    const hasEntryType = await queryRunner.hasColumn(tableName, 'entryType');
+    if (!hasEntryType) {
+      await queryRunner.query(
+        "ALTER TABLE `stock_ledger` ADD `entryType` varchar(10) NOT NULL DEFAULT 'IN'"
+      );
+    }
+
+    // Populate sensible defaults for existing rows so that application logic works as expected.
+    await queryRunner.query(
+      "UPDATE `stock_ledger` SET `entryType` = 'OUT' WHERE `quantity` < 0"
+    );
+    await queryRunner.query(
+      "UPDATE `stock_ledger` SET `entryType` = 'IN' WHERE (`entryType` IS NULL OR `entryType` = '') AND `quantity` >= 0"
+    );
+
+    // Ensure quantities are stored as absolute values to match the current business logic.
+    await queryRunner.query("UPDATE `stock_ledger` SET `quantity` = ABS(`quantity`)");
+  }
+
+  async down(queryRunner) {
+    const tableName = 'stock_ledger';
+    const hasEntryType = await queryRunner.hasColumn(tableName, 'entryType');
+    if (hasEntryType) {
+      await queryRunner.query("ALTER TABLE `stock_ledger` DROP COLUMN `entryType`");
+    }
+  }
+}
+
+module.exports = EnsureStockLedgerEntryType1717000000001;

--- a/backend/src/services/stockLedgerService.js
+++ b/backend/src/services/stockLedgerService.js
@@ -64,6 +64,12 @@ const getEntry = async (id) => {
   return StockLedgerRepository.findOne({ where: { id }, relations: ['product'] });
 };
 
+const normalizeQuantity = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.abs(numeric);
+};
+
 const recordEntry = async ({
   productId,
   quantity,
@@ -75,16 +81,18 @@ const recordEntry = async ({
   sourceItemId = null,
   notes = null,
 }) => {
-  if (!productId || !quantity || !entryType || !sourceType || !sourceId) {
+  const normalizedQuantity = normalizeQuantity(quantity);
+
+  if (!productId || !normalizedQuantity || !entryType || !sourceType || !sourceId) {
     throw new Error('Invalid stock ledger payload');
   }
 
   const entry = StockLedgerRepository.create({
     product: productId,
-    quantity,
+    quantity: normalizedQuantity,
     entryType,
-    costPrice,
-    sellPrice,
+    costPrice: toNumber(costPrice, 0),
+    sellPrice: toNumber(sellPrice, 0),
     sourceType,
     sourceId,
     sourceItemId,


### PR DESCRIPTION
## Summary
- add a migration that ensures the `stock_ledger.entryType` column exists and backfills sensible defaults for legacy rows
- normalize stock ledger payloads before saving to keep quantities positive and numeric values sanitized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eab7ff97788333ae372dbd86211768