### PR TITLE
Add migration to add expense reference column

### DIFF
--- a/backend/src/migrations/1718000000001-AddReferenceToExpenses.js
+++ b/backend/src/migrations/1718000000001-AddReferenceToExpenses.js
@@ -1,0 +1,23 @@
+class AddReferenceToExpenses1718000000001 {
+  async up(queryRunner) {
+    const hasReferenceColumn = await queryRunner.hasColumn('expenses', 'reference');
+    if (!hasReferenceColumn) {
+      await queryRunner.query(`
+        ALTER TABLE \`expenses\`
+        ADD COLUMN \`reference\` varchar(191) NULL AFTER \`description\`
+      `);
+    }
+  }
+
+  async down(queryRunner) {
+    const hasReferenceColumn = await queryRunner.hasColumn('expenses', 'reference');
+    if (hasReferenceColumn) {
+      await queryRunner.query(`
+        ALTER TABLE \`expenses\`
+        DROP COLUMN \`reference\`
+      `);
+    }
+  }
+}
+
+module.exports = AddReferenceToExpenses1718000000001;


### PR DESCRIPTION
## Summary
- add a migration that introduces the missing `reference` column on the `expenses` table so TypeORM queries stop failing
- guard the migration so it only applies when the column is absent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eab71073b08333900f5d00d9b76d95