### PR TITLE
Fix product list retrieval for invoice item selection

### DIFF
--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -52,7 +52,7 @@ export default function ItemRow({
           return;
         }
         setProductsLoading(true);
-        const response = await request.list({ entity: 'products' });
+        const response = await request.list({ entity: 'product' });
         if (!ignore) {
           if (response?.success && Array.isArray(response.result)) {
             cachedProducts = response.result;

--- a/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
+++ b/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
@@ -66,7 +66,7 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
     const fetchProducts = async () => {
       setProductsLoading(true);
       try {
-        const response = await request.list({ entity: 'products' });
+        const response = await request.list({ entity: 'product' });
         if (!ignore && response?.success && Array.isArray(response.result)) {
           setProducts(response.result);
         }


### PR DESCRIPTION
## Summary
- update invoice form to request the singular product entity when loading selectable items
- align shared item row loader with the correct product endpoint so cached results populate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f362c1794483339e8c62484148ade1