### PR TITLE
Handle invoice item discount validation and totals

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/create.js
+++ b/backend/src/controllers/appControllers/invoiceController/create.js
@@ -4,6 +4,7 @@ const Model = AppDataSource.getRepository('Invoice');
 const { calculate } = require('@/helpers');
 const { increaseBySettingKey } = require('@/middlewares/settings');
 const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
+const { computeTotals } = require('@/services/invoiceCalculationService');
 const schema = require('./schemaValidate');
 
 const create = async (req, res) => {
@@ -19,30 +20,39 @@ const create = async (req, res) => {
     });
   }
 
-  const { items = [], taxRate = 0, discount = 0 } = value;
+  const {
+    items = [],
+    taxRate = 0,
+    globalDiscountType,
+    globalDiscountValue,
+  } = value;
 
-  // default
-  let subTotal = 0;
-  let taxTotal = 0;
-  let total = 0;
-
-  //Calculate the items array with subTotal, total, taxTotal
-  items.map((item) => {
-    let total = calculate.multiply(item['quantity'], item['price']);
-    //sub total
-    subTotal = calculate.add(subTotal, total);
-    //item total
-    item['total'] = total;
+  const {
+    items: normalizedItems,
+    subTotal,
+    discountAmount,
+    taxTotal,
+    total,
+    globalDiscountType: normalizedGlobalDiscountType,
+    globalDiscountValue: normalizedGlobalDiscountValue,
+    taxRate: normalizedTaxRate,
+  } = computeTotals({
+    items,
+    globalDiscountType,
+    globalDiscountValue,
+    taxRate,
   });
-  taxTotal = calculate.multiply(subTotal, taxRate / 100);
-  total = calculate.add(subTotal, taxTotal);
 
   body['subTotal'] = subTotal;
   body['taxTotal'] = taxTotal;
   body['total'] = total;
-  body['items'] = items;
+  body['items'] = normalizedItems;
+  body['discount'] = discountAmount;
+  body['globalDiscountType'] = normalizedGlobalDiscountType;
+  body['globalDiscountValue'] = normalizedGlobalDiscountValue;
+  body['taxRate'] = normalizedTaxRate;
 
-  let paymentStatus = calculate.sub(total, discount) === 0 ? 'PAID' : 'UNPAID';
+  let paymentStatus = calculate.sub(total, discountAmount) === 0 ? 'PAID' : 'UNPAID';
 
   body['paymentStatus'] = paymentStatus;
   body['createdBy'] = req.admin.id;

--- a/backend/src/controllers/appControllers/invoiceController/schemaValidate.js
+++ b/backend/src/controllers/appControllers/invoiceController/schemaValidate.js
@@ -1,4 +1,24 @@
 const Joi = require('joi');
+const allowedDiscountTypes = ['NONE', 'PERCENTAGE', 'FIXED'];
+
+const itemSchema = Joi.object({
+  _id: Joi.alternatives().try(Joi.string(), Joi.number()).allow('', null),
+  id: Joi.alternatives().try(Joi.string(), Joi.number()).allow('', null),
+  itemName: Joi.string().required(),
+  description: Joi.string().allow(''),
+  quantity: Joi.number().required(),
+  price: Joi.number().required(),
+  unit: Joi.string().allow('', null),
+  productId: Joi.alternatives().try(Joi.string(), Joi.number()).allow(null),
+  discountType: Joi.string()
+    .uppercase()
+    .valid(...allowedDiscountTypes)
+    .default('NONE'),
+  discountValue: Joi.number().min(0).default(0),
+  total: Joi.number(),
+})
+  .unknown(true);
+
 const schema = Joi.object({
   client: Joi.alternatives().try(Joi.string(), Joi.object(), Joi.number()).required(),
   number: Joi.number().required(),
@@ -7,20 +27,14 @@ const schema = Joi.object({
   notes: Joi.string().allow(''),
   expiredDate: Joi.date().required(),
   date: Joi.date().required(),
-  // array cannot be empty
-  items: Joi.array()
-    .items(
-      Joi.object({
-        _id: Joi.string().allow('').optional(),
-        itemName: Joi.string().required(),
-        description: Joi.string().allow(''),
-        quantity: Joi.number().required(),
-        price: Joi.number().required(),
-        total: Joi.number().required(),
-      }).required()
-    )
-    .required(),
+  items: Joi.array().items(itemSchema.required()).min(1).required(),
   taxRate: Joi.alternatives().try(Joi.number(), Joi.string()).required(),
+  discount: Joi.alternatives().try(Joi.number(), Joi.string()).allow(null),
+  globalDiscountType: Joi.string()
+    .uppercase()
+    .valid(...allowedDiscountTypes)
+    .default('NONE'),
+  globalDiscountValue: Joi.alternatives().try(Joi.number(), Joi.string()).default(0),
 });
 
 module.exports = schema;

--- a/backend/src/controllers/appControllers/invoiceController/update.js
+++ b/backend/src/controllers/appControllers/invoiceController/update.js
@@ -5,6 +5,7 @@ const custom = require('@/controllers/pdfController');
 
 const { calculate } = require('@/helpers');
 const { addId } = require('@/controllers/middlewaresControllers/createCRUDController/utils');
+const { computeTotals } = require('@/services/invoiceCalculationService');
 const schema = require('./schemaValidate');
 
 const update = async (req, res) => {
@@ -24,7 +25,7 @@ const update = async (req, res) => {
 
   const { credit } = previousInvoice;
 
-  const { items = [], taxRate = 0, discount = 0 } = req.body;
+  const { items = [], taxRate, globalDiscountType, globalDiscountValue } = value;
 
   if (items.length === 0) {
     return res.status(400).json({
@@ -34,26 +35,30 @@ const update = async (req, res) => {
     });
   }
 
-  // default
-  let subTotal = 0;
-  let taxTotal = 0;
-  let total = 0;
-
-  //Calculate the items array with subTotal, total, taxTotal
-  items.map((item) => {
-    let total = calculate.multiply(item['quantity'], item['price']);
-    //sub total
-    subTotal = calculate.add(subTotal, total);
-    //item total
-    item['total'] = total;
+  const {
+    items: normalizedItems,
+    subTotal,
+    discountAmount,
+    taxTotal,
+    total,
+    globalDiscountType: normalizedGlobalDiscountType,
+    globalDiscountValue: normalizedGlobalDiscountValue,
+    taxRate: normalizedTaxRate,
+  } = computeTotals({
+    items,
+    globalDiscountType: globalDiscountType ?? previousInvoice.globalDiscountType,
+    globalDiscountValue: globalDiscountValue ?? previousInvoice.globalDiscountValue,
+    taxRate: typeof taxRate !== 'undefined' ? taxRate : previousInvoice.taxRate,
   });
-  taxTotal = calculate.multiply(subTotal, taxRate / 100);
-  total = calculate.add(subTotal, taxTotal);
 
   body['subTotal'] = subTotal;
   body['taxTotal'] = taxTotal;
   body['total'] = total;
-  body['items'] = items;
+  body['items'] = normalizedItems;
+  body['discount'] = discountAmount;
+  body['globalDiscountType'] = normalizedGlobalDiscountType;
+  body['globalDiscountValue'] = normalizedGlobalDiscountValue;
+  body['taxRate'] = normalizedTaxRate;
   body['pdf'] = 'invoice-' + req.params.id + '.pdf';
   if (body.hasOwnProperty('currency')) {
     delete body.currency;
@@ -61,7 +66,7 @@ const update = async (req, res) => {
   // Find document by id and updates with the required fields
 
   let paymentStatus =
-    calculate.sub(total, discount) === credit ? 'paid' : credit > 0 ? 'partially' : 'unpaid';
+    calculate.sub(total, discountAmount) === credit ? 'paid' : credit > 0 ? 'partially' : 'unpaid';
   body['paymentStatus'] = paymentStatus;
 
   Model.merge(previousInvoice, body);

--- a/backend/src/services/invoiceCalculationService.js
+++ b/backend/src/services/invoiceCalculationService.js
@@ -1,0 +1,101 @@
+const { calculate } = require('@/helpers');
+
+const normalizeNumber = (value, fallback = 0) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return parsed;
+};
+
+const normalizeDiscountType = (value) => {
+  if (!value) return 'NONE';
+  const normalized = value.toString().toUpperCase();
+  if (['PERCENTAGE', 'FIXED', 'NONE'].includes(normalized)) {
+    return normalized;
+  }
+  return 'NONE';
+};
+
+const normalizeInvoiceItem = (item = {}) => {
+  const quantity = Math.max(normalizeNumber(item.quantity, 0), 0);
+  const price = Math.max(normalizeNumber(item.price, 0), 0);
+  const discountType = normalizeDiscountType(item.discountType);
+  let discountValue = Math.max(normalizeNumber(item.discountValue, 0), 0);
+
+  const baseTotal = calculate.multiply(price, quantity);
+  let discountAmount = 0;
+
+  if (discountType === 'PERCENTAGE') {
+    discountAmount = calculate.multiply(baseTotal, discountValue / 100);
+  } else if (discountType === 'FIXED') {
+    discountAmount = discountValue;
+  }
+
+  if (discountAmount > baseTotal) {
+    discountAmount = baseTotal;
+  }
+
+  const total = baseTotal > discountAmount ? calculate.sub(baseTotal, discountAmount) : 0;
+
+  return {
+    ...item,
+    quantity,
+    price,
+    discountType,
+    discountValue: discountType === 'NONE' ? 0 : discountValue,
+    total,
+  };
+};
+
+const computeTotals = ({
+  items = [],
+  globalDiscountType = 'NONE',
+  globalDiscountValue = 0,
+  taxRate = 0,
+} = {}) => {
+  const normalizedItems = items.map((item) => normalizeInvoiceItem(item));
+
+  let subTotal = 0;
+  normalizedItems.forEach((item) => {
+    subTotal = calculate.add(subTotal, Number(item.total || 0));
+  });
+
+  const normalizedGlobalDiscountType = normalizeDiscountType(globalDiscountType);
+  let normalizedGlobalDiscountValue = Math.max(normalizeNumber(globalDiscountValue, 0), 0);
+
+  let discountAmount = 0;
+  if (normalizedGlobalDiscountType === 'PERCENTAGE') {
+    discountAmount = calculate.multiply(subTotal, normalizedGlobalDiscountValue / 100);
+  } else if (normalizedGlobalDiscountType === 'FIXED') {
+    discountAmount = normalizedGlobalDiscountValue;
+  }
+
+  if (discountAmount > subTotal) {
+    discountAmount = subTotal;
+  }
+
+  const taxRateValue = Math.max(normalizeNumber(taxRate, 0), 0);
+  const taxableAmount = Math.max(calculate.sub(subTotal, discountAmount), 0);
+  const taxTotal = calculate.multiply(taxableAmount, taxRateValue / 100);
+  const total = calculate.add(subTotal, taxTotal);
+
+  if (normalizedGlobalDiscountType === 'NONE') {
+    normalizedGlobalDiscountValue = 0;
+  }
+
+  return {
+    items: normalizedItems,
+    subTotal,
+    discountAmount,
+    taxTotal,
+    total,
+    globalDiscountType: normalizedGlobalDiscountType,
+    globalDiscountValue: normalizedGlobalDiscountValue,
+    taxRate: taxRateValue,
+  };
+};
+
+module.exports = {
+  normalizeInvoiceItem,
+  computeTotals,
+  normalizeDiscountType,
+};


### PR DESCRIPTION
## Summary
- allow invoice item payloads to include discount metadata and normalize it during validation
- centralize invoice total calculations (item discounts, global discount, and tax) in a reusable service
- update invoice creation and update flows to persist normalized totals, discount amounts, and payment status

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3fd76aca883339866ca8a8a5a657b