### PR TITLE
Add stock to buy status support for purchase invoices

### DIFF
--- a/backend/src/services/purchaseInvoiceService.js
+++ b/backend/src/services/purchaseInvoiceService.js
@@ -225,9 +225,11 @@ const listPurchaseInvoices = async (params = {}) => {
   return { result, total };
 };
 
+const STOCK_TO_BUY_STATUSES = ['sent', 'confirmed', 'stock_to_buy', 'stock to buy', 'Stock To Buy'];
+
 const getStockToBuy = async () => {
   const invoices = await PurchaseInvoiceRepository.find({
-    where: { removed: false, status: In(['sent', 'confirmed']) },
+    where: { removed: false, status: In(STOCK_TO_BUY_STATUSES) },
     relations: ['items', 'items.product'],
   });
 

--- a/frontend/src/modules/PurchaseInvoiceModule/Forms/PurchaseInvoiceForm.jsx
+++ b/frontend/src/modules/PurchaseInvoiceModule/Forms/PurchaseInvoiceForm.jsx
@@ -11,7 +11,7 @@ import PurchaseItemRow from '../components/PurchaseItemRow';
 
 const { Text } = Typography;
 
-const STATUS_OPTIONS = ['draft', 'pending', 'sent', 'confirmed'];
+const STATUS_OPTIONS = ['draft', 'pending', 'sent', 'confirmed', 'stock_to_buy'];
 const DISCOUNT_OPTIONS = ['amount', 'percent'];
 
 export default function PurchaseInvoiceForm({ totals }) {


### PR DESCRIPTION
## Summary
- include the new Stock To Buy status when aggregating purchase invoices for the stock-to-buy report
- expose the Stock To Buy status in the purchase invoice form so users can select it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f48b6ae4ec8333873949ed251883f7