### PR TITLE
Improve stock-to-buy status handling

### DIFF
--- a/backend/src/services/purchaseInvoiceService.js
+++ b/backend/src/services/purchaseInvoiceService.js
@@ -225,19 +225,41 @@ const listPurchaseInvoices = async (params = {}) => {
   return { result, total };
 };
 
+const normalizeStatusValue = (value = '') =>
+  String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+
+const STOCK_TO_BUY_STATUSES = ['sent', 'confirmed', 'stock_to_buy'];
+
+const STOCK_TO_BUY_STATUS_ALIASES = Array.from(
+  new Set(
+    STOCK_TO_BUY_STATUSES.flatMap((status) => {
+      const spaced = status.replace(/_/g, ' ');
+      const pascal = spaced.replace(/\b\w/g, (char) => char.toUpperCase());
+      const upper = status.toUpperCase();
+      const snakePascal = pascal.replace(/\s+/g, '_');
+      return [status, spaced, pascal, upper, snakePascal, spaced.toLowerCase()];
+    })
+  )
+);
+
 const getStockToBuy = async () => {
   const invoices = await PurchaseInvoiceRepository.find({
-    where: { removed: false, status: In(['sent', 'confirmed']) },
+    where: { removed: false, status: In(STOCK_TO_BUY_STATUS_ALIASES) },
     relations: ['items', 'items.product'],
   });
 
   const grouped = new Map();
-  invoices.forEach((invoice) => {
-    (invoice.items || []).forEach((item) => {
-      if (!item.product) return;
-      const productId = item.product.id || item.product;
-      if (!grouped.has(productId)) {
-        grouped.set(productId, {
+  invoices
+    .filter((invoice) => STOCK_TO_BUY_STATUSES.includes(normalizeStatusValue(invoice.status)))
+    .forEach((invoice) => {
+      (invoice.items || []).forEach((item) => {
+        if (!item.product) return;
+        const productId = item.product.id || item.product;
+        if (!grouped.has(productId)) {
+          grouped.set(productId, {
           productId,
           productName: item.product.name || '',
           quantity: 0,
@@ -247,7 +269,6 @@ const getStockToBuy = async () => {
       const entry = grouped.get(productId);
       entry.quantity = calculate.add(entry.quantity, item.quantity);
     });
-  });
 
   const productIds = Array.from(grouped.keys());
   if (productIds.length) {

--- a/frontend/src/modules/PurchaseInvoiceModule/Forms/PurchaseInvoiceForm.jsx
+++ b/frontend/src/modules/PurchaseInvoiceModule/Forms/PurchaseInvoiceForm.jsx
@@ -11,7 +11,7 @@ import PurchaseItemRow from '../components/PurchaseItemRow';
 
 const { Text } = Typography;
 
-const STATUS_OPTIONS = ['draft', 'pending', 'sent', 'confirmed'];
+const STATUS_OPTIONS = ['draft', 'pending', 'sent', 'confirmed', 'stock_to_buy'];
 const DISCOUNT_OPTIONS = ['amount', 'percent'];
 
 export default function PurchaseInvoiceForm({ totals }) {

--- a/frontend/src/modules/PurchaseInvoiceModule/PurchaseInvoiceDataTableModule.jsx
+++ b/frontend/src/modules/PurchaseInvoiceModule/PurchaseInvoiceDataTableModule.jsx
@@ -44,6 +44,7 @@ export default function PurchaseInvoiceDataTableModule({ config }) {
     {
       title: translate('status'),
       dataIndex: 'status',
+      render: (value) => (value ? translate(value) : ''),
     },
   ];
 

--- a/frontend/src/modules/PurchaseInvoiceModule/index.jsx
+++ b/frontend/src/modules/PurchaseInvoiceModule/index.jsx
@@ -5,8 +5,10 @@ import purchaseInvoiceService from '@/services/purchaseInvoiceService';
 
 const statusOptions = [
   { value: 'draft', label: 'draft', color: 'default' },
+  { value: 'pending', label: 'pending', color: 'orange' },
   { value: 'sent', label: 'sent', color: 'blue' },
   { value: 'confirmed', label: 'confirmed', color: 'green' },
+  { value: 'stock_to_buy', label: 'stock_to_buy', color: 'volcano' },
   { value: 'paid', label: 'paid', color: 'gold' },
 ];
 


### PR DESCRIPTION
## Summary
- normalise purchase invoice statuses so Stock To Buy entries are included in the stock-to-buy report regardless of text casing or separators
- expose the Stock To Buy status in the purchase invoice CRUD options and translate status values in the table for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f48b6ae4ec8333873949ed251883f7