### PR TITLE
Fetch all products for selection components

### DIFF
--- a/frontend/src/components/MultiStepSelectAsync/index.jsx
+++ b/frontend/src/components/MultiStepSelectAsync/index.jsx
@@ -5,7 +5,11 @@ import errorHandler from '@/request/errorHandler';
 
 const { Option } = Select;
 
-const asyncList = (entity) => {
+const asyncList = async (entity) => {
+  const response = await request.listAll({ entity });
+  if (response?.success || Array.isArray(response?.result)) {
+    return response;
+  }
   return request.list({ entity });
 };
 

--- a/frontend/src/components/SelectAsync/index.jsx
+++ b/frontend/src/components/SelectAsync/index.jsx
@@ -24,7 +24,11 @@ const SelectAsync = ({
 
   const navigate = useNavigate();
 
-  const asyncList = () => {
+  const asyncList = async () => {
+    const response = await request.listAll({ entity });
+    if (response?.success || Array.isArray(response?.result)) {
+      return response;
+    }
     return request.list({ entity });
   };
   const { result, isLoading: fetchIsLoading, isSuccess } = useFetch(asyncList);

--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -52,7 +52,10 @@ export default function ItemRow({
           return;
         }
         setProductsLoading(true);
-        const response = await request.list({ entity: 'product' });
+        let response = await request.listAll({ entity: 'product' });
+        if (!(response?.success || Array.isArray(response?.result))) {
+          response = await request.list({ entity: 'product' });
+        }
         if (!ignore) {
           if (response?.success && Array.isArray(response.result)) {
             cachedProducts = response.result;

--- a/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
+++ b/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
@@ -66,7 +66,10 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
     const fetchProducts = async () => {
       setProductsLoading(true);
       try {
-        const response = await request.list({ entity: 'product' });
+        let response = await request.listAll({ entity: 'product' });
+        if (!(response?.success || Array.isArray(response?.result))) {
+          response = await request.list({ entity: 'product' });
+        }
         if (!ignore && response?.success && Array.isArray(response.result)) {
           setProducts(response.result);
         }


### PR DESCRIPTION
## Summary
- update the shared async select helpers to load complete datasets via the listAll API
- ensure invoice and ERP item forms fetch the full product catalog with a fallback to the paginated endpoint

## Testing
- npm run lint *(fails: frontend ESLint config is CommonJS and cannot be loaded as ESM in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4b99fa1348333bfb5e22b158f3f2a