### PR TITLE
Add client information and purchase shortcut to stock to buy

### DIFF
--- a/backend/src/services/purchaseInvoiceService.js
+++ b/backend/src/services/purchaseInvoiceService.js
@@ -264,6 +264,7 @@ const getStockToBuy = async () => {
             productName: item.product.name || '',
             quantity: 0,
             lastCostPrice: 0,
+            clients: [],
           });
         }
         const entry = grouped.get(productId);

--- a/frontend/src/locale/translation/en_us.js
+++ b/frontend/src/locale/translation/en_us.js
@@ -383,6 +383,7 @@ const lang = {
   invoice_list: 'Invoice List',
   add_new_invoice: 'Add New Invoice',
   record_payment: 'Record Payment',
+  record_purchase: 'Record Purchase',
   tax_total: 'Tax Total',
   show_invoice: 'Show Invoice',
   payment_status: 'Payment Status',

--- a/frontend/src/modules/PurchaseInvoiceModule/StockToBuyModule.jsx
+++ b/frontend/src/modules/PurchaseInvoiceModule/StockToBuyModule.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Card, Table, Button, Space } from 'antd';
 import { ReloadOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
 
 import { ErpLayout } from '@/layout';
 import useLanguage from '@/locale/useLanguage';
@@ -12,6 +13,7 @@ export default function StockToBuyModule() {
   const translate = useLanguage();
   const { moneyFormatter } = useMoney();
   const { result, isLoading, onFetch } = useOnFetch();
+  const navigate = useNavigate();
 
   useEffect(() => {
     onFetch(request.get({ entity: 'purchaseinvoice/stock-to-buy' }));
@@ -21,10 +23,22 @@ export default function StockToBuyModule() {
     onFetch(request.get({ entity: 'purchaseinvoice/stock-to-buy' }));
   };
 
+  const handleRecordPurchase = () => {
+    navigate('/purchaseinvoice');
+  };
+
   const columns = [
     {
       title: translate('Product'),
       dataIndex: 'productName',
+    },
+    {
+      title: translate('client'),
+      dataIndex: 'clients',
+      render: (clients) => {
+        const names = Array.isArray(clients) ? clients.filter(Boolean) : [];
+        return names.length ? names.join(', ') : translate('none');
+      },
     },
     {
       title: translate('Quantity'),
@@ -39,6 +53,17 @@ export default function StockToBuyModule() {
       title: translate('Last sell price'),
       dataIndex: 'lastSellPrice',
       render: (value) => moneyFormatter({ amount: value }),
+    },
+    {
+      title: '',
+      dataIndex: 'actions',
+      key: 'actions',
+      align: 'right',
+      render: () => (
+        <Button type="primary" onClick={handleRecordPurchase}>
+          {translate('record_purchase')}
+        </Button>
+      ),
     },
   ];
 

--- a/frontend/src/modules/StockToBuyModule/index.jsx
+++ b/frontend/src/modules/StockToBuyModule/index.jsx
@@ -1,3 +1,6 @@
+import { Button } from 'antd';
+import { useNavigate } from 'react-router-dom';
+
 import { ErpLayout } from '@/layout';
 import ErpPanel from '@/modules/ErpPanelModule';
 import useLanguage from '@/locale/useLanguage';
@@ -8,11 +11,24 @@ const StockToBuyModule = () => {
   const translate = useLanguage();
   const { moneyFormatter } = useMoney();
   const entity = stockToBuyService.entity;
+  const navigate = useNavigate();
+
+  const handleRecordPurchase = () => {
+    navigate('/purchaseinvoice');
+  };
 
   const dataTableColumns = [
     {
       title: translate('product'),
       dataIndex: 'productName',
+    },
+    {
+      title: translate('client'),
+      dataIndex: 'clients',
+      render: (clients) => {
+        const names = Array.isArray(clients) ? clients.filter(Boolean) : [];
+        return names.length ? names.join(', ') : translate('none');
+      },
     },
     {
       title: translate('quantity'),
@@ -29,6 +45,17 @@ const StockToBuyModule = () => {
       dataIndex: 'lastSellPrice',
       render: (value, record) =>
         moneyFormatter({ amount: value || 0, currency_code: record?.currency || 'NA' }),
+    },
+    {
+      title: '',
+      dataIndex: 'actions',
+      key: 'actions',
+      align: 'right',
+      render: () => (
+        <Button type="primary" onClick={handleRecordPurchase}>
+          {translate('record_purchase')}
+        </Button>
+      ),
     },
   ];
 

--- a/frontend/src/services/stockToBuyService.js
+++ b/frontend/src/services/stockToBuyService.js
@@ -24,6 +24,36 @@ const ensureArray = (value) => {
   return [];
 };
 
+const normalizeClientNames = (value) => {
+  const names = new Set();
+
+  const append = (client) => {
+    if (client == null) return;
+    if (Array.isArray(client)) {
+      client.forEach(append);
+      return;
+    }
+    if (typeof client === 'string') {
+      const trimmed = client.trim();
+      if (trimmed) names.add(trimmed);
+      return;
+    }
+    if (typeof client === 'object') {
+      append(client.name);
+      append(client.fullName);
+      append(client.companyName);
+      append(client.company);
+      append(client.label);
+      append(client.clientName);
+      return;
+    }
+    append(String(client));
+  };
+
+  append(value);
+  return Array.from(names);
+};
+
 const fetchInvoicesWithStatus = async (status = 'stock_to_buy') => {
   const invoices = [];
   let page = 1;
@@ -57,6 +87,11 @@ const extractInvoiceEntries = (invoices = []) => {
   const entries = [];
   invoices.forEach((invoice) => {
     const items = ensureArray(invoice.items);
+    const clientNames = normalizeClientNames([
+      invoice?.client,
+      invoice?.clientName,
+      invoice?.clientLabel,
+    ]);
     items.forEach((item) => {
       const product = item?.product;
       const productId =
@@ -71,6 +106,7 @@ const extractInvoiceEntries = (invoices = []) => {
         lastSellPrice: toNumber(item?.price),
         lastCostPrice: toNumber(item?.costPrice),
         currency: invoice?.currency,
+        clients: clientNames,
       });
     });
   });
@@ -85,6 +121,7 @@ const normalizePurchaseEntries = (records = []) =>
     lastCostPrice: toNumber(entry?.lastCostPrice),
     lastSellPrice: toNumber(entry?.lastSellPrice),
     currency: entry?.currency,
+    clients: normalizeClientNames(entry?.clients),
   }));
 
 const mergeEntries = (entries = []) => {
@@ -108,6 +145,7 @@ const mergeEntries = (entries = []) => {
         lastCostPrice: toNumber(entry.lastCostPrice),
         lastSellPrice: toNumber(entry.lastSellPrice),
         currency: entry.currency,
+        clients: normalizeClientNames(entry.clients),
       });
       return;
     }
@@ -129,6 +167,7 @@ const mergeEntries = (entries = []) => {
     if ((current.productId === key || current.productId == null) && entry.productId) {
       current.productId = entry.productId;
     }
+    current.clients = normalizeClientNames([current.clients, entry.clients]);
   });
 
   return Array.from(grouped.values());


### PR DESCRIPTION
## Summary
- surface client names throughout the stock-to-buy data pipeline
- add a client column and Record Purchase button to the stock-to-buy tables
- localize the Record Purchase label for reuse across the app

## Testing
- npm run lint *(fails: ESLint cannot load CommonJS config when run under ESM; see ReferenceError in output)*

------
https://chatgpt.com/codex/tasks/task_e_68fd401e5af08333900b2f26dd6597ef