### PR TITLE
Fix MySQL 5.5 default-value error on admin_passwords.loggedSessions

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js
@@ -42,7 +42,15 @@ const isValidAuthToken = async (req, res, next, { userModel, jwtSecret = 'JWT_SE
         jwtExpired: true,
       });
 
-    const { loggedSessions } = userPassword;
+    if (!userPassword)
+      return res.status(401).json({
+        success: false,
+        result: null,
+        message: "User password credentials doens't Exist, authorization denied.",
+        jwtExpired: true,
+      });
+
+    const loggedSessions = userPassword.loggedSessions || [];
 
     if (!loggedSessions.includes(token))
       return res.status(401).json({

--- a/backend/src/entities/AdminPassword.js
+++ b/backend/src/entities/AdminPassword.js
@@ -12,7 +12,9 @@ module.exports = new EntitySchema({
     resetToken: { type: 'varchar', nullable: true },
     emailVerified: { type: 'boolean', default: false },
     authType: { type: 'varchar', default: 'email' },
-    loggedSessions: { type: 'simple-json', default: () => "'[]'" },
+    // MySQL 5.5 does not allow defaults on TEXT/BLOB columns.
+    // `simple-json` is persisted as TEXT, so keep it nullable and initialize in app code.
+    loggedSessions: { type: 'simple-json', nullable: true },
     created: { type: 'datetime', default: () => 'CURRENT_TIMESTAMP' },
     updated: { type: 'datetime', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' },
   },


### PR DESCRIPTION
### Motivation
- Startup schema sync failed with `ER_BLOB_CANT_HAVE_DEFAULT` because `loggedSessions` used a DB-level default while `simple-json` is persisted as `TEXT` and MySQL 5.5 disallows defaults on `TEXT/BLOB` columns.

### Description
- Changed `loggedSessions` in `backend/src/entities/AdminPassword.js` from ` { type: 'simple-json', default: () => "'[]'" }` to ` { type: 'simple-json', nullable: true }` and added a comment explaining the MySQL 5.5 constraint.
- Hardened token validation in `backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js` by returning a 401 when the `userPassword` record is missing and by using `userPassword.loggedSessions || []` before calling `.includes(...)`.
- Kept session behavior in application code (login/reset/logout) unchanged so `loggedSessions` is still initialized at runtime where needed.

### Testing
- Ran `node --check backend/src/entities/AdminPassword.js` which completed successfully.
- Ran `node --check backend/src/controllers/middlewaresControllers/createAuthMiddleware/isValidAuthToken.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eebc72ab88333a297510a50057a31)