### PR TITLE
fix(recap): count converted invoices and use net sales totals

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -159,21 +159,22 @@ also exist (generic CRUD vs `masterData/*Service`).
   the dead REST routes and add an RBAC guard in the generic path for these entities. Pick one code
   path and delete the other.
 
-### 🟡 D. Sales global discount is excluded from `invoice.total`, and recap reads it raw
+### 🟡 D. Sales global discount is excluded from `invoice.total`, and recap reads it raw — ✅ FIXED
 `services/invoiceCalculationService.js:79` computes `total = subTotal + taxTotal` (the global
 discount is computed but **not** subtracted). The system's convention is that net due =
 `total - discount` (used in `invoiceController/create.js` and `invoiceService.updateInvoicePayment`).
-But `recapService.getSalesData` sums raw `invoice.total`, so **recap sales are overstated** by the
+`recapService.getSalesData` summed raw `invoice.total`, so recap sales were overstated by the
 global discount amount.
-- Fix direction: either make `total` the net figure (and adjust the payment-due math + FE display),
-  or make recap use `total - discount`. Be consistent across invoice display, payment, and recap.
+- **Fixed**: `recapService.getSalesData` now uses net `total - discount` per invoice (sales side
+  only — purchase totals are already net). The gross-`total` convention was left unchanged to avoid
+  touching the payment-due math + FE display; revisit as part of bug G if a fuller cleanup is wanted.
 
-### 🟡 E. Converted quote→invoice is invisible to recap
-`quoteService.convertQuoteToInvoice` never sets the new invoice's `status`, so it defaults to
-`'draft'`. `recapService` filters `status != 'draft'`, so converted invoices don't appear in recap
-until their status is changed.
-- Fix direction: set an appropriate non-draft status on conversion (e.g. `pending`/`sent` per the
-  intended workflow).
+### 🟡 E. Converted quote→invoice is invisible to recap — ✅ FIXED
+`quoteService.convertQuoteToInvoice` never set the new invoice's `status`, so it defaulted to
+`'draft'`. `recapService` filters `status != 'draft'`, so converted invoices didn't appear in recap
+until their status was changed.
+- **Fixed**: `convertQuoteToInvoice` now sets `status: 'pending'` on the new invoice (a valid FE
+  status value, meaning a real invoice awaiting payment), so it is counted by recap.
 
 ### 🟡 F. Status / paymentStatus casing is inconsistent
 Quote uses UPPER (`SENT`, `CONVERTED`); invoice/purchase `status` use lower (`draft`, `sent`);
@@ -205,7 +206,7 @@ CRUD auto-wiring, MySQL legacy-compat bootstrap.
 control, and discount/total semantics across the different invoice creation paths.
 
 ## 10. Suggested fix order (safest first)
-1. **D + E** — recap correctness. Low blast radius, no schema change.
+1. ~~**D + E** — recap correctness. Low blast radius, no schema change.~~ ✅ DONE
 2. **C** — master-data RBAC. Security; choose one code path.
 3. **B then A** — stock pair, do together. B needs the opening-balance design decision first.
 4. **F, G, I, H** — consistency & cleanup.

--- a/backend/src/services/quoteService.js
+++ b/backend/src/services/quoteService.js
@@ -34,6 +34,9 @@ const convertQuoteToInvoice = async (id, adminId) => {
     discount: quote.discount,
     notes: quote.notes,
     createdBy: adminId,
+    // Converted invoices must leave 'draft' so they appear in the recap report
+    // (recap filters out draft invoices). 'pending' = real invoice awaiting payment.
+    status: 'pending',
     paymentStatus: 'unpaid',
     credit: 0,
   };

--- a/backend/src/services/recapService.js
+++ b/backend/src/services/recapService.js
@@ -25,13 +25,19 @@ const getSalesData = async (startDate, endDate) => {
   const where = { removed: false, status: Not('draft') };
   if (period) where.date = period;
   const invoices = await InvoiceRepository.find({ where, order: { date: 'ASC', id: 'ASC' } });
-  const items = invoices.map((invoice) => ({
-    id: invoice.id,
-    number: invoice.number,
-    date: invoice.date,
-    client: invoice.client,
-    total: invoice.total,
-  }));
+  const items = invoices.map((invoice) => {
+    // Sales invoice `total` is gross (global discount is stored separately in `discount`
+    // and only subtracted at payment time). Net revenue = total - discount, matching
+    // invoiceService.updateInvoicePayment's due calculation. Purchases are already net.
+    const netTotal = Number(invoice.total || 0) - Number(invoice.discount || 0);
+    return {
+      id: invoice.id,
+      number: invoice.number,
+      date: invoice.date,
+      client: invoice.client,
+      total: netTotal,
+    };
+  });
   const total = items.reduce((sum, item) => sum + Number(item.total || 0), 0);
   return { items, total };
 };


### PR DESCRIPTION
Fixes two recap-report correctness bugs (D and E in `HANDOVER.md`). Backend only, no schema change.

## E — Converted quote→invoice was missing from recap
`quoteService.convertQuoteToInvoice` never set the new invoice's `status`, so it defaulted to `'draft'`. `recapService` filters out `'draft'`, so converted invoices never showed up in the report.
- **Fix**: conversion now sets `status: 'pending'` (a valid FE status = a real invoice awaiting payment).

## D — Recap sales were overstated by the global discount
Sales invoice `total` is **gross**: the global discount is stored separately in `discount`, and net due = `total - discount` (see `invoiceService.updateInvoicePayment`). `recapService.getSalesData` summed the raw gross `total`, overstating sales (and therefore profit).
- **Fix**: `getSalesData` now sums `total - discount` per invoice. **Sales side only** — purchase totals are already net (`purchaseInvoiceService` subtracts the global discount), so purchases are untouched.
- The gross-`total` convention itself is left unchanged to avoid touching payment-due math and the FE display; a fuller cleanup is tracked as bug **G**.

## Verification
- `node --check` passes on both edited services.
- No automated test suite exists in the repo. Manual check recommended: create a quote with a discount → send → convert → confirm the invoice appears in `/reports/recap` with `total - discount` as its sales figure.

## Notes for reviewer
- `paymentStatus` casing inconsistency (bug **F**) is intentionally **not** touched here.
- `HANDOVER.md` known-bug log updated to mark D and E as fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)