### PR TITLE
fix(invoice): canonicalize paymentStatus casing to lowercase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,13 +87,16 @@ Read the relevant service before changing a flow.
 - Before changing any flow, check the chain: **entity → service → controller → route → FE module → recap**.
 - Always reason about side effects on: invoice total, payment status, stock quantity, stock-ledger
   history, recap/profit.
-- Status string casing is inconsistent across modules (see HANDOVER bug **F**) — match the exact
-  casing the target module already uses; don't "normalize" globally without checking all readers.
+- Status casing convention (HANDOVER bug **F**, fixed): `invoice.paymentStatus` is canonical
+  **lowercase** `unpaid|paid|partially`; `invoice`/`purchaseInvoice` `status` are lowercase
+  (`draft|pending|sent`); `quote.status` is an UPPER enum (`DRAFT|SENT|CONVERTED`). Match the target
+  field's casing and don't "normalize" globally without checking all readers (FE `statusTagColor`,
+  `invoiceController/summary`, i18n keys).
 - Keep changes small and safe. When a fix needs a design decision (e.g. stock opening balance),
   surface it before editing.
 
 ## Known issues
 A full, verified, ranked list with file:line and fix direction is in **[HANDOVER.md](HANDOVER.md)
 → Known Bugs**. Fixed: sales stock OUT (A), aggregate double-count (B), master-data RBAC (C),
-recap discount + converted-invoice visibility (D, E). Still open (low priority): status casing (F),
-overloaded `discount` field (G), orphan entities (H), FE-driven numbering (I).
+recap discount + converted-invoice visibility (D, E), paymentStatus casing (F). Still open
+(low priority): overloaded `discount` field (G), orphan entities (H), FE-driven numbering (I).

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -188,12 +188,21 @@ until their status was changed.
 - **Fixed**: `convertQuoteToInvoice` now sets `status: 'pending'` on the new invoice (a valid FE
   status value, meaning a real invoice awaiting payment), so it is counted by recap.
 
-### 🟡 F. Status / paymentStatus casing is inconsistent
-Quote uses UPPER (`SENT`, `CONVERTED`); invoice/purchase `status` use lower (`draft`, `sent`);
-`paymentStatus` mixes (entity default `UNPAID` upper, `quoteService` writes lowercase `unpaid`,
-`invoiceService` writes `UNPAID|PAID|PARTIAL`). Frontend equality checks are fragile.
-- Fix direction: define a canonical casing per field and normalize on write + read. Audit all
-  readers (FE included) before changing.
+### 🟡 F. Status / paymentStatus casing is inconsistent — ✅ FIXED
+`invoice.paymentStatus` was written in three different forms: `create.js` wrote `PAID`/`UNPAID`,
+`invoiceService.updateInvoicePayment` (the `/invoices/:id/payments` path) wrote `PAID|PARTIAL|UNPAID`,
+while `update.js`, `paymentController/*` and `quoteService` already wrote lowercase
+`paid|partially|unpaid`. The two payment-recording paths therefore disagreed, and the entity default
+was `UNPAID`. Readers expect **lowercase**: BE `invoiceController/summary.js` and the i18n keys, FE
+`utils/statusTagColor`.
+- **Fixed**: canonical `paymentStatus` casing is **lowercase `unpaid | paid | partially`**.
+  Normalized the three uppercase writers — `Invoice` entity default, `invoiceController/create.js`,
+  and `invoiceService.updateInvoicePayment` (also `PARTIAL` → `partially`). `summary.js` now compares
+  case-insensitively so legacy rows still count; FE `tagColor()` was already case-insensitive.
+- Out of scope: `quote.status` stays UPPER (`DRAFT|SENT|CONVERTED`) — it is a self-consistent enum;
+  `invoice`/`purchaseInvoice` `status` were already lowercase-consistent. Pre-existing DB rows with
+  uppercase `paymentStatus` are legacy data (no migration framework) — tags render fine via the
+  case-insensitive lookup; only raw-text displays of old rows stay uppercase.
 
 ### 🔵 G. The `discount` field is overloaded
 `invoiceController/create.js` sets `invoice.discount` = computed global-discount **amount**, while
@@ -224,7 +233,8 @@ edited (quote items have no product link).
 1. ~~**D + E** — recap correctness. Low blast radius, no schema change.~~ ✅ DONE
 2. ~~**C** — master-data RBAC. Security; choose one code path.~~ ✅ DONE
 3. ~~**B then A** — stock pair, do together. B needs the opening-balance design decision first.~~ ✅ DONE
-4. **F, G, I, H** — consistency & cleanup. *(still open)*
+4. ~~**F** — paymentStatus casing.~~ ✅ DONE
+5. **G, I, H** — consistency & cleanup. *(still open)*
 
 Always re-check the impact chain after any change:
 **invoice total → payment status → stock quantity → stock-ledger history → recap/profit.**

--- a/backend/src/controllers/appControllers/invoiceController/create.js
+++ b/backend/src/controllers/appControllers/invoiceController/create.js
@@ -53,7 +53,7 @@ const create = async (req, res) => {
   body['globalDiscountValue'] = normalizedGlobalDiscountValue;
   body['taxRate'] = normalizedTaxRate;
 
-  let paymentStatus = calculate.sub(total, discountAmount) === 0 ? 'PAID' : 'UNPAID';
+  let paymentStatus = calculate.sub(total, discountAmount) === 0 ? 'paid' : 'unpaid';
 
   body['paymentStatus'] = paymentStatus;
   body['createdBy'] = req.admin.id;

--- a/backend/src/controllers/appControllers/invoiceController/summary.js
+++ b/backend/src/controllers/appControllers/invoiceController/summary.js
@@ -36,16 +36,17 @@ const summary = async (req, res) => {
     if (status === 'overdue') {
       count = invoices.filter((i) => i.expiredDate && i.expiredDate < new Date()).length;
     } else if (['paid', 'unpaid', 'partially'].includes(status)) {
-      count = invoices.filter((i) => i.paymentStatus === status).length;
+      // Compare case-insensitively so legacy rows with uppercase paymentStatus still count.
+      count = invoices.filter((i) => (i.paymentStatus || '').toLowerCase() === status).length;
     } else {
-      count = invoices.filter((i) => i.status === status).length;
+      count = invoices.filter((i) => (i.status || '').toLowerCase() === status).length;
     }
     const percentage = totalInvoices.count ? Math.round((count / totalInvoices.count) * 100) : 0;
     return { status, count, percentage };
   });
 
   const unpaid = invoices
-    .filter((i) => ['unpaid', 'partially'].includes(i.paymentStatus))
+    .filter((i) => ['unpaid', 'partially'].includes((i.paymentStatus || '').toLowerCase()))
     .reduce((acc, i) => acc + (i.total - i.credit), 0);
 
   const finalResult = {

--- a/backend/src/entities/Invoice.js
+++ b/backend/src/entities/Invoice.js
@@ -26,7 +26,7 @@ module.exports = new EntitySchema({
     globalDiscountType: { type: 'varchar', length: 50, default: 'NONE' },
     globalDiscountValue: { type: 'decimal', precision: 10, scale: 2, default: 0 },
     payment: { type: 'simple-json', nullable: true },
-    paymentStatus: { type: 'varchar', default: 'UNPAID' },
+    paymentStatus: { type: 'varchar', default: 'unpaid' },
     isOverdue: { type: 'boolean', default: false },
     approved: { type: 'boolean', default: false },
     notes: { type: 'text', nullable: true },

--- a/backend/src/services/invoiceService.js
+++ b/backend/src/services/invoiceService.js
@@ -15,11 +15,13 @@ const updateInvoicePayment = async (invoiceId) => {
   const payments = await PaymentRepository.find({ where: { invoice: invoiceId, removed: false } });
   const paid = payments.reduce((sum, p) => calculate.add(sum, p.amount), 0);
   const due = calculate.sub(calculate.sub(invoice.total, invoice.discount || 0), paid);
-  let status = 'UNPAID';
+  // Canonical paymentStatus casing is lowercase (matches FE statusTagColor,
+  // invoiceController/summary, and the i18n keys): 'unpaid' | 'paid' | 'partially'.
+  let status = 'unpaid';
   if (due <= 0) {
-    status = 'PAID';
+    status = 'paid';
   } else if (paid > 0) {
-    status = 'PARTIAL';
+    status = 'partially';
   }
   invoice.credit = paid;
   invoice.paymentStatus = status;


### PR DESCRIPTION
Fixes bug **F** from `HANDOVER.md`. Backend only, no schema change.

> ⚠️ **Stacked on #119 → #118 → #117** (base = `fix/sales-stock-and-aggregate`). Merge order: #117, #118, #119, then this. GitHub auto-retargets as each base merges.

## Problem
`invoice.paymentStatus` was written in three different forms:
- `invoiceController/create.js` → `PAID` / `UNPAID`
- `invoiceService.updateInvoicePayment` (the `/invoices/:id/payments` path) → `PAID` / `PARTIAL` / `UNPAID`
- `invoiceController/update.js`, `paymentController/*`, `quoteService` → lowercase `paid` / `partially` / `unpaid`

So the **two payment-recording paths disagreed**, the entity default was `UNPAID`, and `PARTIAL` ≠ the `partially` spelling everyone else uses. Readers expect lowercase: BE `invoiceController/summary.js` and the i18n keys, FE `utils/statusTagColor`.

## Fix
Canonical `paymentStatus` = **lowercase `unpaid | paid | partially`**.
- Normalized the three uppercase writers: `Invoice` entity default, `create.js`, and `invoiceService.updateInvoicePayment` (`PARTIAL` → `partially`).
- `summary.js` now compares `paymentStatus`/`status` **case-insensitively** so legacy rows still count. FE `tagColor()` was already case-insensitive.

## Scope / notes
- `quote.status` intentionally stays an UPPER enum (`DRAFT|SENT|CONVERTED`); `invoice`/`purchaseInvoice` `status` were already lowercase-consistent — left alone.
- Pre-existing DB rows with uppercase `paymentStatus` are legacy data; there is no migration framework, so they are not rewritten. Tags still render via the case-insensitive lookup; only raw-text displays of old rows remain uppercase.

## Verification
- `node --check` passes on all 4 changed backend files.
- `grep` confirms no uppercase `PAID|UNPAID|PARTIAL` literals remain in `backend/src`.
- No automated test suite. Manual check: record a payment via both paths (`/payment/create` and the invoice "Record Payment" screen → `/invoices/:id/payments`) → both yield lowercase `paid`/`partially`; the status tag shows the right colour and the dashboard summary counts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)