### PR TITLE
fix(db): coerce DATE column writes to YYYY-MM-DD

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "backend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev:backend"],
+      "port": 8888
+    },
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev:frontend"],
+      "port": 3000
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,9 @@ Read the relevant service before changing a flow.
   product form's stock value is captured as an `adjustment` entry. Don't write these columns directly.
 - **Auth/session**: JWT tokens are also stored in `AdminPassword.loggedSessions` (JSON array).
   Every request checks `token ∈ loggedSessions`; **logout removes the token** (real invalidation).
+- **Dates**: every `type: 'date'` column is MySQL `DATE` (date-only). `typeorm-data-source.js`
+  (`normalizeDateOnlyColumns`) attaches a transformer that coerces any written value (the FE sends
+  full ISO `…T…Z` timestamps) to `YYYY-MM-DD`. Don't re-add per-controller date parsing — see HANDOVER **J**.
 
 ### Frontend conventions
 - All API calls use the **action-suffix** shape via `request/request.js`

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -227,6 +227,18 @@ The client supplies `number`; `last_invoice_number` is incremented separately. Q
 the quote's `number` verbatim. Concurrent creates can collide. Consider server-authoritative,
 per-(year) sequence allocation.
 
+### 🔴 J. MySQL `DATE` columns reject the frontend's ISO datetime strings — ✅ FIXED
+Saving an invoice failed with `Incorrect datetime value: '2026-06-18T03:28:18.047Z' for column
+'date'`. The dayjs date pickers serialize to a full ISO-8601 timestamp (date + time + `Z`), but
+`invoices.date` / `expiredDate` (and `quotes`, `payments`, `purchase_invoices`, `expenses` date
+columns) are MySQL `DATE` (date-only). The controllers persisted `req.body` verbatim, so MySQL (strict
+mode) rejected the format. Affected every `type: 'date'` column on any FE-driven create/update.
+- **Fixed centrally**: `typeorm-data-source.js` now attaches a write transformer to **every**
+  `type: 'date'` column (`normalizeDateOnlyColumns`) that coerces any incoming value (ISO string /
+  `Date` / `YYYY-MM-DD…`) to a plain `YYYY-MM-DD` before it reaches MySQL. One fix covers all entities
+  and all write paths; no controller changes. Verified end-to-end: a create with
+  `'2026-06-18T03:28:18.047Z'` now returns 200 and stores `2026-06-18`.
+
 ---
 
 ## 9. What's solid vs fragile

--- a/backend/src/typeorm-data-source.js
+++ b/backend/src/typeorm-data-source.js
@@ -26,6 +26,55 @@ const StockLedger = require('./entities/StockLedger');
 const { ensureBootstrapData } = require('./setup/bootstrapDefaults');
 
 
+// MySQL `DATE` columns reject full ISO datetime strings such as
+// '2026-06-18T03:28:18.047Z' ("Incorrect datetime value"). The frontend date
+// pickers (dayjs) serialize to exactly that. Attach a write transformer to every
+// `type: 'date'` column so any incoming value (ISO string / Date / 'YYYY-MM-DD')
+// is coerced to a plain 'YYYY-MM-DD' before it reaches MySQL.
+function coerceToDateOnly(value) {
+  if (value === null || value === undefined || value === '') return value;
+
+  const formatLocal = (date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? value : formatLocal(value);
+  }
+
+  const stringValue = String(value);
+  // Already starts with a date part (e.g. '2026-06-18' or '2026-06-18T03:28:18Z')
+  // -> keep that date part verbatim (avoids any timezone shift).
+  const isoMatch = stringValue.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (isoMatch) return isoMatch[1];
+
+  const parsed = new Date(stringValue);
+  return Number.isNaN(parsed.getTime()) ? value : formatLocal(parsed);
+}
+
+function normalizeDateOnlyColumns(entities) {
+  for (const entity of entities) {
+    const columns = entity?.options?.columns;
+    if (!columns) continue;
+
+    for (const columnOptions of Object.values(columns)) {
+      if (!columnOptions || typeof columnOptions !== 'object') continue;
+      const isDateType =
+        typeof columnOptions.type === 'string' && columnOptions.type.toLowerCase() === 'date';
+      // Don't clobber a column that already defines its own transformer.
+      if (!isDateType || columnOptions.transformer) continue;
+
+      columnOptions.transformer = {
+        to: coerceToDateOnly,
+        from: (value) => value,
+      };
+    }
+  }
+}
+
 function normalizeLegacyDateColumns(entities) {
   for (const entity of entities) {
     const columns = entity?.options?.columns;
@@ -214,6 +263,7 @@ const entities = [
 
 normalizeLegacyAuditColumns(entities);
 normalizeLegacyDateColumns(entities);
+normalizeDateOnlyColumns(entities);
 
 const AppDataSource = new DataSource({
   ...connectionConfig,


### PR DESCRIPTION
Fixes the **500 on invoice save**:
`Incorrect datetime value: '2026-06-18T03:28:18.047Z' for column \`invoices\`.\`date\` at row 1`.

Fresh off `Rollback2` (no stacking). Backend only, no schema change.

## Cause
The dayjs date pickers serialize to a full ISO-8601 timestamp (`2026-06-18T03:28:18.047Z`), but `invoices.date`/`expiredDate` — and the date columns on `quotes`, `payments`, `purchase_invoices`, `expenses` — are MySQL **`DATE`** (date-only). The controllers persist `req.body` verbatim, so MySQL (strict mode) rejected the `…T…Z` format. This affected **every** `type: 'date'` column on any FE-driven create/update, not just invoices.

## Fix
Central, single point: `typeorm-data-source.js` now attaches a write transformer to every `type: 'date'` column (`normalizeDateOnlyColumns`) that coerces any incoming value (ISO string / `Date` / `YYYY-MM-DD…`) to a plain `YYYY-MM-DD` before it reaches MySQL. The date part is taken verbatim from an ISO prefix (no timezone shift). Read side unchanged. No controller changes — covers invoice, quote, payment, purchase, expense at once.

## Verification (end-to-end, real backend + MySQL)
- `node --check` passes; backend reloaded cleanly (DataSource init + MySQL connect OK with the transformer attached).
- Unit-tested the coercion: `2026-06-18T03:28:18.047Z` → `2026-06-18`; `Date` objects, `YYYY-MM-DD`, empty/null/invalid all handled.
- **Live**: `POST /api/invoice/create` with `date: '2026-06-18T03:28:18.047Z'` → **200**, stored `date`/`expiredDate` = `2026-06-18`. (Test invoice created as `draft` and deleted afterwards — no leftover data, no stock movement.)

Docs: `HANDOVER.md` (new bug **J**) and `CLAUDE.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)